### PR TITLE
Add shared foundations: account, config keys, MCP result and MIME helpers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,44 @@ MCP_BEARER_TOKEN=
 # Coupe-circuit pour l'envoi : passer a false desactive send_message et
 # reply_message (les deux renvoient une erreur claire), le reste des outils
 # n'est pas affecte. Par defaut a true.
+# Reconnus comme "desactive" : false, 0, no (insensible a la casse, trim).
 ENABLE_SENDING=true
+
+# --- Garde-fous d'envoi -------------------------------------------------------
+# Toutes optionnelles : les valeurs ci-dessous sont les defauts.
+
+# Taille maximale d'une piece jointe, en octets (defaut : 5 Mio).
+ATTACHMENT_MAX_BYTES=5242880
+
+# Destinataires autorises : liste d'adresses ou de domaines separes par des
+# virgules. Vide = aucun filtrage.
+ALLOWED_RECIPIENTS=
+
+# Nombre maximal d'envois par jour glissant. 0 = illimite.
+MAX_SENDS_PER_DAY=0
+
+# Force tous les envois a passer par un brouillon : aucun mail n'est emis.
+# Meme grammaire booleenne que ENABLE_SENDING.
+DRAFTS_ONLY=false
+
+# Leve tous les garde-fous d'envoi ci-dessus. A n'utiliser qu'en connaissance
+# de cause.
+UNRESTRICTED=false
+
+# Longueur maximale d'un corps de message (texte ou HTML) accepte par les outils.
+MAX_BODY_CHARS=20000
+
+# --- Protocole MCP / sessions ------------------------------------------------
+# Toutes optionnelles : les valeurs ci-dessous sont les defauts.
+
+# Transport expose par le serveur MCP : http | stdio | both.
+MCP_TRANSPORT=http
+
+# Plafond d'appels d'outils par minute et par session.
+RATE_LIMIT_PER_MINUTE=120
+
+# Duree de vie d'une session inactive, en millisecondes (defaut : 30 min).
+SESSION_TTL_MS=1800000
 
 # --- Cloudflare Tunnel (docker-compose) -----------------------------------------
 # Token du tunnel, genere dans le dashboard Cloudflare Zero Trust

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,6 +101,34 @@ envoyez depuis Mail.
 
 ---
 
+## Garde-fous d'envoi
+
+Toutes optionnelles. Vides ou absentes, elles laissent le comportement historique inchangé.
+
+| Variable | Défaut | Description |
+|---|---|---|
+| `ATTACHMENT_MAX_BYTES` | `5242880` | Taille maximale d'une pièce jointe, en octets (5 Mio). |
+| `ALLOWED_RECIPIENTS` | `''` | Liste d'adresses ou de domaines séparés par des virgules. Vide = aucun filtrage. Exposée aussi normalisée en tableau (`ALLOWED_RECIPIENTS_LIST` : trim, minuscules, entrées vides retirées). |
+| `MAX_SENDS_PER_DAY` | `0` | Nombre maximal d'envois par jour glissant. `0` = illimité. |
+| `DRAFTS_ONLY` | `false` | `true` force tout envoi à passer par un brouillon : aucun mail n'est émis. Même grammaire booléenne que `ENABLE_SENDING`. |
+| `UNRESTRICTED` | `false` | `true` lève tous les garde-fous d'envoi ci-dessus. À n'utiliser qu'en connaissance de cause. |
+| `MAX_BODY_CHARS` | `20000` | Longueur maximale d'un corps de message (texte ou HTML) accepté par les outils. |
+
+Les clés booléennes (`DRAFTS_ONLY`, `UNRESTRICTED`) suivent la même règle que `ENABLE_SENDING` :
+`false`, `0`, `no` (insensible à la casse, espaces ignorés) valent faux, toute autre valeur vaut vrai.
+
+---
+
+## Protocole MCP et sessions
+
+| Variable | Défaut | Description |
+|---|---|---|
+| `MCP_TRANSPORT` | `http` | Transport exposé par le serveur : `http`, `stdio` ou `both`. Une autre valeur fait échouer le démarrage. |
+| `RATE_LIMIT_PER_MINUTE` | `120` | Plafond d'appels d'outils par minute et par session. |
+| `SESSION_TTL_MS` | `1800000` | Durée de vie d'une session inactive, en millisecondes (30 min). |
+
+---
+
 ## Logs
 
 | Variable | Défaut | Description |

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,0 +1,20 @@
+import { config } from './config.js';
+
+/**
+ * Compte mail unique dérivé de la configuration. Point d'accès unique aux
+ * identifiants et aux serveurs, pour préparer un éventuel multi-compte sans
+ * l'implémenter : rien n'expose de notion de compte aux outils MCP aujourd'hui.
+ */
+export interface MailAccount {
+  email: string;
+  password: string;
+  imap: { host: string; port: number };
+  smtp: { host: string; port: number };
+}
+
+export const account: MailAccount = {
+  email: config.ICLOUD_EMAIL,
+  password: config.ICLOUD_APP_PASSWORD,
+  imap: { host: config.IMAP_HOST, port: config.IMAP_PORT },
+  smtp: { host: config.SMTP_HOST, port: config.SMTP_PORT },
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,29 @@
 import 'dotenv/config';
 import { z } from 'zod';
 
+/**
+ * Booléen tolérant lu depuis l'environnement. Volontairement pas un
+ * `z.coerce.boolean()` : dans zod, la chaîne `"false"` est une chaîne non vide,
+ * donc coercée à `true` — un coupe-circuit `FLAG=false` serait silencieusement
+ * inopérant. Ici `"false"`, `"0"` et `"no"` (insensibles à la casse, espaces
+ * ignorés) valent faux ; toute autre valeur vaut vrai ; l'absence de variable
+ * retombe sur `defaultValue`.
+ */
+export function envBool(defaultValue: boolean): z.ZodType<boolean, unknown> {
+  return z
+    .string()
+    .optional()
+    .transform((v) => (v === undefined ? defaultValue : !['false', '0', 'no'].includes(v.trim().toLowerCase())));
+}
+
+/** Découpe une liste séparée par des virgules en entrées normalisées (trim, minuscules, vides retirées). */
+export function parseList(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.length > 0);
+}
+
 const envSchema = z.object({
   ICLOUD_EMAIL: z.string().email('ICLOUD_EMAIL doit être une adresse email valide'),
   ICLOUD_APP_PASSWORD: z.string().min(1, 'ICLOUD_APP_PASSWORD est requis'),
@@ -13,13 +36,34 @@ const envSchema = z.object({
   MCP_BEARER_TOKEN: z.string().min(16, 'MCP_BEARER_TOKEN doit faire au moins 16 caractères'),
   PORT: z.coerce.number().int().positive().default(3000),
   LOG_LEVEL: z.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace']).default('info'),
-  // Coupe-circuit pour send_message / reply_message. Volontairement pas un simple
-  // z.coerce.boolean() : dans zod, "false" est une chaîne non-vide donc coercée à `true`.
-  ENABLE_SENDING: z
-    .string()
-    .optional()
-    .default('true')
-    .transform((v) => !['false', '0', 'no'].includes(v.trim().toLowerCase())),
+
+  // Coupe-circuit pour send_message / reply_message.
+  ENABLE_SENDING: envBool(true),
+
+  // --- Garde-fous d'envoi (lot D) ------------------------------------------
+  // Taille maximale d'une pièce jointe, en octets.
+  ATTACHMENT_MAX_BYTES: z.coerce.number().int().positive().default(5_242_880),
+  // Destinataires autorisés : adresses ou domaines séparés par des virgules.
+  // Vide = aucun filtrage. Exposé aussi en tableau via ALLOWED_RECIPIENTS_LIST.
+  ALLOWED_RECIPIENTS: z.string().default(''),
+  // Nombre maximal d'envois par jour glissant. 0 = illimité.
+  MAX_SENDS_PER_DAY: z.coerce.number().int().nonnegative().default(0),
+  // Force tous les envois à passer par un brouillon (aucun mail n'est émis).
+  DRAFTS_ONLY: envBool(false),
+  // Lève tous les garde-fous d'envoi. À n'utiliser qu'en connaissance de cause.
+  UNRESTRICTED: envBool(false),
+
+  // --- Protocole MCP / sessions (lots C, E) -------------------------------
+  // Plafond d'appels par minute et par session.
+  RATE_LIMIT_PER_MINUTE: z.coerce.number().int().positive().default(120),
+  // Durée de vie d'une session inactive, en millisecondes.
+  SESSION_TTL_MS: z.coerce.number().int().positive().default(1_800_000),
+  // Transport exposé par le serveur MCP.
+  MCP_TRANSPORT: z
+    .enum(['http', 'stdio', 'both'], { message: 'MCP_TRANSPORT doit valoir "http", "stdio" ou "both"' })
+    .default('http'),
+  // Longueur maximale d'un corps de message (texte ou HTML) accepté par les outils.
+  MAX_BODY_CHARS: z.coerce.number().int().positive().default(20_000),
 });
 
 /** Valide un environnement arbitraire. Exporté pour les tests ; l'app utilise `config`. */
@@ -29,7 +73,11 @@ export function parseConfig(env: NodeJS.ProcessEnv = process.env) {
     const issues = parsed.error.issues.map((issue) => `  - ${issue.path.join('.')}: ${issue.message}`).join('\n');
     throw new Error(`Configuration invalide (voir .env / .env.example) :\n${issues}`);
   }
-  return parsed.data;
+  return {
+    ...parsed.data,
+    /** `ALLOWED_RECIPIENTS` normalisé en tableau (vide = aucun filtrage). */
+    ALLOWED_RECIPIENTS_LIST: parseList(parsed.data.ALLOWED_RECIPIENTS),
+  };
 }
 
 export const config = parseConfig(process.env);

--- a/src/imap/drafts.ts
+++ b/src/imap/drafts.ts
@@ -1,5 +1,4 @@
-import MailComposer from 'nodemailer/lib/mail-composer/index.js';
-import { config } from '../config.js';
+import { composeRaw } from '../smtp/compose.js';
 import { imapPool } from './pool.js';
 import { classifyImapError } from './errors.js';
 import { findSpecialFolder } from './special-folders.js';
@@ -49,8 +48,7 @@ export async function saveDraft(input: DraftInput): Promise<DraftResult> {
     throw new Error('Sujet requis, sauf en réponse à un message existant (replyFolder + replyUid).');
   }
 
-  const raw = await new MailComposer({
-    from: config.ICLOUD_EMAIL,
+  const raw = await composeRaw({
     to,
     cc: input.cc,
     bcc: input.bcc,
@@ -59,9 +57,7 @@ export async function saveDraft(input: DraftInput): Promise<DraftResult> {
     html: input.html,
     inReplyTo,
     references,
-  })
-    .compile()
-    .build();
+  });
 
   try {
     return await imapPool.withConnection(async (client) => {

--- a/src/imap/pool.ts
+++ b/src/imap/pool.ts
@@ -1,4 +1,5 @@
 import { ImapFlow } from 'imapflow';
+import { account } from '../account.js';
 import { config } from '../config.js';
 import { logger } from '../logger.js';
 import { classifyImapError, ImapNetworkError } from './errors.js';
@@ -15,12 +16,12 @@ export type ImapClientFactory = () => ImapFlow;
 
 function defaultClientFactory(): ImapFlow {
   return new ImapFlow({
-    host: config.IMAP_HOST,
-    port: config.IMAP_PORT,
+    host: account.imap.host,
+    port: account.imap.port,
     secure: true,
     auth: {
-      user: config.ICLOUD_EMAIL,
-      pass: config.ICLOUD_APP_PASSWORD,
+      user: account.email,
+      pass: account.password,
     },
     logger: false,
   });
@@ -183,7 +184,7 @@ export class ImapConnectionPool {
       throw classifyImapError(err);
     }
 
-    log.info({ host: config.IMAP_HOST }, 'imap connection established');
+    log.info({ host: account.imap.host }, 'imap connection established');
     return client;
   }
 

--- a/src/mcp/result.ts
+++ b/src/mcp/result.ts
@@ -1,0 +1,17 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * Résultat MCP « succès » : les données sérialisées en JSON indenté dans un
+ * bloc texte. Les 10 outils répétaient ce motif à l'identique.
+ *
+ * La signature est stable volontairement : le lot C y ajoutera
+ * `structuredContent` sans toucher aux appelants.
+ */
+export function jsonResult(data: unknown): CallToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+}
+
+/** Résultat MCP « erreur » : `isError: true` et le message (en français) en texte. */
+export function errorResult(message: string): CallToolResult {
+  return { isError: true, content: [{ type: 'text', text: message }] };
+}

--- a/src/mcp/tools/delete-message.ts
+++ b/src/mcp/tools/delete-message.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { deleteMessage } from '../../imap/mutations.js';
+import { jsonResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'delete_message' });
@@ -21,7 +22,7 @@ export function registerDeleteMessageTool(server: McpServer): void {
     async ({ folder, uid }) => {
       log.info({ folder, uid }, 'deleting message');
       const result = await deleteMessage(folder, uid);
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      return jsonResult(result);
     },
   );
 }

--- a/src/mcp/tools/flag-message.ts
+++ b/src/mcp/tools/flag-message.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { flagMessage } from '../../imap/mutations.js';
+import { jsonResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'flag_message' });
@@ -23,7 +24,7 @@ export function registerFlagMessageTool(server: McpServer): void {
     async ({ folder, uid, actions }) => {
       log.info({ folder, uid, actions }, 'flagging message');
       const result = await flagMessage(folder, uid, actions);
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      return jsonResult(result);
     },
   );
 }

--- a/src/mcp/tools/get-message.ts
+++ b/src/mcp/tools/get-message.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { getMessage } from '../../imap/messages.js';
+import { jsonResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'get_message' });
@@ -21,7 +22,7 @@ export function registerGetMessageTool(server: McpServer): void {
     async ({ folder, uid }) => {
       log.info({ folder, uid }, 'fetching message');
       const message = await getMessage(folder, uid);
-      return { content: [{ type: 'text', text: JSON.stringify(message, null, 2) }] };
+      return jsonResult(message);
     },
   );
 }

--- a/src/mcp/tools/list-folders.ts
+++ b/src/mcp/tools/list-folders.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { listFolders } from '../../imap/folders.js';
+import { jsonResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'list_folders' });
@@ -15,14 +16,7 @@ export function registerListFoldersTool(server: McpServer): void {
     async () => {
       log.info('listing folders');
       const folders = await listFolders();
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(folders, null, 2),
-          },
-        ],
-      };
+      return jsonResult(folders);
     },
   );
 }

--- a/src/mcp/tools/list-messages.ts
+++ b/src/mcp/tools/list-messages.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { listMessages } from '../../imap/messages.js';
+import { jsonResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'list_messages' });
@@ -40,7 +41,7 @@ export function registerListMessagesTool(server: McpServer): void {
         from,
         limit,
       });
-      return { content: [{ type: 'text', text: JSON.stringify(messages, null, 2) }] };
+      return jsonResult(messages);
     },
   );
 }

--- a/src/mcp/tools/move-message.ts
+++ b/src/mcp/tools/move-message.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { moveMessage } from '../../imap/mutations.js';
+import { jsonResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'move_message' });
@@ -22,7 +23,7 @@ export function registerMoveMessageTool(server: McpServer): void {
     async ({ folder, uid, destination }) => {
       log.info({ folder, uid, destination }, 'moving message');
       const result = await moveMessage(folder, uid, destination);
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      return jsonResult(result);
     },
   );
 }

--- a/src/mcp/tools/reply-message.ts
+++ b/src/mcp/tools/reply-message.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { sendReply } from '../../smtp/send.js';
+import { errorResult, jsonResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'reply_message' });
@@ -25,15 +26,12 @@ export function registerReplyMessageTool(server: McpServer): void {
     },
     async ({ folder, uid, to, cc, bcc, text, html }) => {
       if (!text && !html) {
-        return {
-          isError: true,
-          content: [{ type: 'text', text: 'Fournir au moins un corps de message (text ou html).' }],
-        };
+        return errorResult('Fournir au moins un corps de message (text ou html).');
       }
 
       log.info({ folder, uid }, 'replying to message');
       const result = await sendReply({ folder, uid, to, cc, bcc, text, html });
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      return jsonResult(result);
     },
   );
 }

--- a/src/mcp/tools/save-draft.ts
+++ b/src/mcp/tools/save-draft.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { saveDraft } from '../../imap/drafts.js';
+import { errorResult, jsonResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'save_draft' });
@@ -27,21 +28,15 @@ export function registerSaveDraftTool(server: McpServer): void {
     },
     async ({ to, cc, bcc, subject, text, html, replyFolder, replyUid }) => {
       if (!text && !html) {
-        return {
-          isError: true,
-          content: [{ type: 'text', text: 'Fournir au moins un corps de message (text ou html).' }],
-        };
+        return errorResult('Fournir au moins un corps de message (text ou html).');
       }
       if ((replyFolder && !replyUid) || (!replyFolder && replyUid)) {
-        return {
-          isError: true,
-          content: [{ type: 'text', text: 'replyFolder et replyUid doivent être fournis ensemble.' }],
-        };
+        return errorResult('replyFolder et replyUid doivent être fournis ensemble.');
       }
 
       log.info({ to, subject, replyFolder, replyUid }, 'saving draft');
       const result = await saveDraft({ to, cc, bcc, subject, text, html, replyFolder, replyUid });
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      return jsonResult(result);
     },
   );
 }

--- a/src/mcp/tools/search-messages.ts
+++ b/src/mcp/tools/search-messages.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { searchMessages } from '../../imap/messages.js';
+import { errorResult, jsonResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'search_messages' });
@@ -24,17 +25,12 @@ export function registerSearchMessagesTool(server: McpServer): void {
     },
     async ({ folder, subject, body, from, to, limit }) => {
       if (!subject && !body && !from && !to) {
-        return {
-          isError: true,
-          content: [
-            { type: 'text', text: 'Au moins un critère de recherche est requis (subject, body, from ou to).' },
-          ],
-        };
+        return errorResult('Au moins un critère de recherche est requis (subject, body, from ou to).');
       }
 
       log.info({ folder, subject, from, to }, 'searching messages');
       const messages = await searchMessages(folder, { subject, body, from, to, limit });
-      return { content: [{ type: 'text', text: JSON.stringify(messages, null, 2) }] };
+      return jsonResult(messages);
     },
   );
 }

--- a/src/mcp/tools/send-message.ts
+++ b/src/mcp/tools/send-message.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { sendNewMessage } from '../../smtp/send.js';
+import { errorResult, jsonResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'send_message' });
@@ -22,15 +23,12 @@ export function registerSendMessageTool(server: McpServer): void {
     },
     async ({ to, cc, bcc, subject, text, html }) => {
       if (!text && !html) {
-        return {
-          isError: true,
-          content: [{ type: 'text', text: 'Fournir au moins un corps de message (text ou html).' }],
-        };
+        return errorResult('Fournir au moins un corps de message (text ou html).');
       }
 
       log.info({ to, subject }, 'sending message');
       const result = await sendNewMessage({ to, cc, bcc, subject, text, html });
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      return jsonResult(result);
     },
   );
 }

--- a/src/smtp/client.ts
+++ b/src/smtp/client.ts
@@ -1,4 +1,5 @@
 import nodemailer from 'nodemailer';
+import { account } from '../account.js';
 import { config } from '../config.js';
 import { logger } from '../logger.js';
 import { classifySmtpError, SmtpMessageError, SmtpNetworkError } from './errors.js';
@@ -6,13 +7,13 @@ import { classifySmtpError, SmtpMessageError, SmtpNetworkError } from './errors.
 const log = logger.child({ module: 'smtp' });
 
 const transporter = nodemailer.createTransport({
-  host: config.SMTP_HOST,
-  port: config.SMTP_PORT,
+  host: account.smtp.host,
+  port: account.smtp.port,
   secure: false, // STARTTLS sur le port 587, pas de TLS implicite
   requireTLS: true,
   auth: {
-    user: config.ICLOUD_EMAIL,
-    pass: config.ICLOUD_APP_PASSWORD,
+    user: account.email,
+    pass: account.password,
   },
   pool: true,
   maxConnections: config.SMTP_POOL_SIZE,
@@ -61,7 +62,7 @@ export async function sendMail(message: OutgoingMessage): Promise<SendResult> {
   }
 
   const mailOptions: MailOptions = {
-    from: config.ICLOUD_EMAIL,
+    from: account.email,
     to: message.to,
     cc: message.cc,
     bcc: message.bcc,

--- a/src/smtp/compose.ts
+++ b/src/smtp/compose.ts
@@ -1,0 +1,51 @@
+import MailComposer from 'nodemailer/lib/mail-composer/index.js';
+import { account } from '../account.js';
+
+export interface ComposeAttachment {
+  filename: string;
+  contentType?: string;
+  content: Buffer;
+  contentDisposition?: 'attachment' | 'inline';
+  cid?: string;
+}
+
+export interface ComposeInput {
+  from?: string; // défaut : account.email
+  to: string[];
+  cc?: string[];
+  bcc?: string[];
+  subject: string;
+  text?: string;
+  html?: string;
+  inReplyTo?: string;
+  references?: string[];
+  attachments?: ComposeAttachment[];
+}
+
+/**
+ * Fabrique MIME unique du projet. Produit le message RFC 5322 brut (avec un
+ * Message-ID généré) à partir d'une intention d'envoi. Utilisée par les
+ * brouillons IMAP et, à terme, par l'envoi SMTP.
+ */
+export async function composeRaw(input: ComposeInput): Promise<Buffer> {
+  return new MailComposer({
+    from: input.from ?? account.email,
+    to: input.to,
+    cc: input.cc,
+    bcc: input.bcc,
+    subject: input.subject,
+    text: input.text,
+    html: input.html,
+    inReplyTo: input.inReplyTo,
+    references: input.references,
+    attachments: input.attachments?.map((attachment) => ({
+      filename: attachment.filename,
+      contentType: attachment.contentType,
+      content: attachment.content,
+      contentDisposition: attachment.contentDisposition,
+      cid: attachment.cid,
+    })),
+  })
+    .compile()
+    .build();
+}

--- a/test/compose.test.ts
+++ b/test/compose.test.ts
@@ -1,0 +1,73 @@
+import './helpers/env.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { composeRaw } from '../src/smtp/compose.js';
+import type { ComposeInput } from '../src/smtp/compose.js';
+
+async function rawText(input: ComposeInput): Promise<string> {
+  return (await composeRaw(input)).toString('utf8');
+}
+
+function headerValue(raw: string, name: string): string | undefined {
+  // En-têtes potentiellement repliés sur plusieurs lignes (RFC 5322 §2.2.3).
+  const match = raw.match(new RegExp(`^${name}:\\s*((?:.*(?:\\r?\\n[ \\t].*)*))`, 'im'));
+  return match?.[1]?.replace(/\r?\n[ \t]/g, ' ').trim();
+}
+
+const base: ComposeInput = {
+  to: ['alice@example.com'],
+  subject: 'Compte rendu',
+  text: 'Bonjour',
+};
+
+describe('composeRaw', () => {
+  it('produit les en-têtes From/To/Cc/Subject', async () => {
+    const raw = await rawText({
+      ...base,
+      to: ['alice@example.com', 'bob@example.com'],
+      cc: ['carol@example.com'],
+    });
+    assert.equal(headerValue(raw, 'From'), 'test@example.com');
+    assert.match(headerValue(raw, 'To') ?? '', /alice@example\.com/);
+    assert.match(headerValue(raw, 'To') ?? '', /bob@example\.com/);
+    assert.equal(headerValue(raw, 'Cc'), 'carol@example.com');
+    assert.equal(headerValue(raw, 'Subject'), 'Compte rendu');
+  });
+
+  it("utilise le champ from fourni plutôt que l'adresse du compte", async () => {
+    const raw = await rawText({ ...base, from: 'perso@example.net' });
+    assert.equal(headerValue(raw, 'From'), 'perso@example.net');
+  });
+
+  it('pose In-Reply-To et References pour une réponse', async () => {
+    const raw = await rawText({
+      ...base,
+      inReplyTo: '<original@example.com>',
+      references: ['<ancetre@example.com>', '<original@example.com>'],
+    });
+    assert.equal(headerValue(raw, 'In-Reply-To'), '<original@example.com>');
+    const references = headerValue(raw, 'References') ?? '';
+    assert.match(references, /<ancetre@example\.com>/);
+    assert.match(references, /<original@example\.com>/);
+  });
+
+  it('génère un Message-ID unique à chaque appel', async () => {
+    const idOf = (raw: string) => raw.match(/^Message-ID:\s*<([^>]+)>/im)?.[1];
+    const first = idOf(await rawText(base));
+    const second = idOf(await rawText(base));
+    assert.ok(first, 'Message-ID présent');
+    assert.ok(second, 'Message-ID présent');
+    assert.notEqual(first, second);
+  });
+
+  it('encode une pièce jointe', async () => {
+    const raw = await rawText({
+      ...base,
+      attachments: [{ filename: 'note.txt', content: Buffer.from('hello world'), contentType: 'text/plain' }],
+    });
+    assert.match(raw, /Content-Disposition: attachment;[\s\S]*?filename=/i);
+    assert.match(raw, /name="?note\.txt"?/i);
+    // "hello world" encodé en base64.
+    assert.match(raw, /aGVsbG8gd29ybGQ=/);
+  });
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,7 +1,7 @@
 import './helpers/env.js';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseConfig } from '../src/config.js';
+import { envBool, parseConfig, parseList } from '../src/config.js';
 
 const validEnv = {
   ICLOUD_EMAIL: 'user@icloud.com',
@@ -71,6 +71,79 @@ describe('parseConfig', () => {
 
     it("est actif par défaut quand la variable n'est pas définie", () => {
       assert.equal(parseConfig({ ...validEnv }).ENABLE_SENDING, true);
+    });
+  });
+
+  describe('nouvelles clés : valeurs par défaut', () => {
+    it('applique les défauts des garde-fous et du protocole', () => {
+      const config = parseConfig({ ...validEnv });
+      assert.equal(config.ATTACHMENT_MAX_BYTES, 5_242_880);
+      assert.equal(config.ALLOWED_RECIPIENTS, '');
+      assert.deepEqual(config.ALLOWED_RECIPIENTS_LIST, []);
+      assert.equal(config.MAX_SENDS_PER_DAY, 0);
+      assert.equal(config.DRAFTS_ONLY, false);
+      assert.equal(config.UNRESTRICTED, false);
+      assert.equal(config.RATE_LIMIT_PER_MINUTE, 120);
+      assert.equal(config.SESSION_TTL_MS, 1_800_000);
+      assert.equal(config.MCP_TRANSPORT, 'http');
+      assert.equal(config.MAX_BODY_CHARS, 20_000);
+    });
+
+    it('normalise ALLOWED_RECIPIENTS en tableau (trim, minuscules, vides retirés)', () => {
+      const config = parseConfig({
+        ...validEnv,
+        ALLOWED_RECIPIENTS: ' Alice@Example.com , example.org ,, ',
+      });
+      assert.deepEqual(config.ALLOWED_RECIPIENTS_LIST, ['alice@example.com', 'example.org']);
+    });
+
+    it('convertit les nouvelles clés numériques', () => {
+      const config = parseConfig({ ...validEnv, MAX_SENDS_PER_DAY: '10', MAX_BODY_CHARS: '500' });
+      assert.equal(config.MAX_SENDS_PER_DAY, 10);
+      assert.equal(config.MAX_BODY_CHARS, 500);
+    });
+
+    it('accepte les valeurs valides de MCP_TRANSPORT', () => {
+      for (const value of ['http', 'stdio', 'both']) {
+        assert.equal(parseConfig({ ...validEnv, MCP_TRANSPORT: value }).MCP_TRANSPORT, value);
+      }
+    });
+
+    it('rejette un MCP_TRANSPORT inconnu avec un message lisible', () => {
+      assert.throws(
+        () => parseConfig({ ...validEnv, MCP_TRANSPORT: 'grpc' }),
+        (err: Error) =>
+          err.message.includes('MCP_TRANSPORT') && err.message.includes('"http", "stdio" ou "both"'),
+      );
+    });
+  });
+
+  describe('envBool', () => {
+    for (const value of ['false', '0', 'no', 'FALSE ', ' No ']) {
+      it(`traite ${JSON.stringify(value)} comme faux`, () => {
+        assert.equal(envBool(true).parse(value), false);
+      });
+    }
+
+    for (const value of ['true', '1', 'yes', 'peu importe']) {
+      it(`traite ${JSON.stringify(value)} comme vrai`, () => {
+        assert.equal(envBool(false).parse(value), true);
+      });
+    }
+
+    it('retombe sur la valeur par défaut quand la variable est absente', () => {
+      assert.equal(envBool(true).parse(undefined), true);
+      assert.equal(envBool(false).parse(undefined), false);
+    });
+  });
+
+  describe('parseList', () => {
+    it('découpe, trim et met en minuscules', () => {
+      assert.deepEqual(parseList('A, b ,  C '), ['a', 'b', 'c']);
+    });
+
+    it('retourne un tableau vide pour une chaîne vide', () => {
+      assert.deepEqual(parseList(''), []);
     });
   });
 });


### PR DESCRIPTION
Introduce the pieces the parallel feature lots all depend on, so they are
written once here instead of six times.

- src/account.ts: single MailAccount derived from config; imap/pool.ts and
  smtp/client.ts now read `account` instead of `config` directly. No
  multi-account surface is exposed.
- src/config.ts: extract the tolerant boolean parser as `envBool`, reused by
  ENABLE_SENDING, DRAFTS_ONLY and UNRESTRICTED. Add optional keys with defaults:
  ATTACHMENT_MAX_BYTES, ALLOWED_RECIPIENTS (+ normalized ALLOWED_RECIPIENTS_LIST),
  MAX_SENDS_PER_DAY, DRAFTS_ONLY, UNRESTRICTED, RATE_LIMIT_PER_MINUTE,
  SESSION_TTL_MS, MCP_TRANSPORT, MAX_BODY_CHARS. Document them in .env.example
  and docs/configuration.md.
- src/mcp/result.ts: jsonResult / errorResult helpers; replace the repeated
  result literals in all 10 tools.
- src/smtp/compose.ts: composeRaw, the project's single MIME factory, extracted
  from imap/drafts.ts; saveDraft now uses it.
- Extend test/config.test.ts, add test/compose.test.ts. 129 tests, no network.

Closes #1
Closes #2

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
