### PR TITLE
Add MCP protocol citizenship: stdio, structured output, resources, prompts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,10 +26,23 @@ SMTP_HOST=smtp.mail.me.com
 SMTP_PORT=587
 SMTP_POOL_SIZE=2
 
+# --- Transport MCP ------------------------------------------------------------
+# http  : serveur HTTP streamable (defaut, cf. deploiement de reference).
+# stdio : serveur JSON-RPC sur stdin/stdout, pour un client MCP local.
+# both  : les deux en parallele.
+# En stdio, les logs basculent automatiquement sur stderr : stdout porte le
+# canal JSON-RPC et la moindre ligne parasite le corromprait.
+MCP_TRANSPORT=http
+
 # --- Serveur HTTP MCP -----------------------------------------------------------
 # Port d'ecoute interne au conteneur. Le docker-compose ne l'expose pas
 # directement : tout passe par le sidecar cloudflared (voir plus bas).
+# Ignore si MCP_TRANSPORT=stdio.
 PORT=3000
+
+# Plafond par defaut, en caracteres, du corps renvoye par get_message.
+# Surchargeable par appel via le parametre maxBodyChars.
+MAX_BODY_CHARS=20000
 
 # Token statique requis dans le header "Authorization: Bearer <token>" pour
 # tout appel au endpoint /mcp. Genere avec : openssl rand -hex 32
@@ -39,6 +52,12 @@ MCP_BEARER_TOKEN=
 # reply_message (les deux renvoient une erreur claire), le reste des outils
 # n'est pas affecte. Par defaut a true.
 ENABLE_SENDING=true
+
+# Active l'outil wait_for_new_message (attente IDLE sur une connexion dediee
+# hors pool). OFF par defaut : cette version n'a pas de reconnexion, donc
+# l'attente se degrade silencieusement si la connexion iCloud saute. Voir
+# docs/configuration.md.
+ENABLE_IDLE_WATCH=false
 
 # --- Cloudflare Tunnel (docker-compose) -----------------------------------------
 # Token du tunnel, genere dans le dashboard Cloudflare Zero Trust

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,12 +61,23 @@ si le serveur refuse de passer en TLS, l'envoi échoue au lieu de partir en clai
 
 ---
 
+## Transport MCP
+
+| Variable | Défaut | Description |
+|---|---|---|
+| `MCP_TRANSPORT` | `http` | `http`, `stdio` ou `both`. Voir [deployment.md](deployment.md#choisir-le-transport). |
+| `MAX_BODY_CHARS` | `20000` | Plafond par défaut, en caractères, du corps renvoyé par `get_message`. Surchargeable par appel via `maxBodyChars`. |
+
+En `stdio`, stdout porte le canal JSON-RPC : le serveur bascule automatiquement ses logs sur stderr.
+
+---
+
 ## Serveur HTTP
 
 | Variable | Défaut | Description |
 |---|---|---|
-| `PORT` | `3000` | Port d'écoute. En Docker, port interne au réseau du compose : le conteneur ne l'expose pas à l'hôte. |
-| `MCP_BEARER_TOKEN` | **requis** | Token attendu dans `Authorization: Bearer <token>` sur `/mcp`. 16 caractères minimum. |
+| `PORT` | `3000` | Port d'écoute. En Docker, port interne au réseau du compose : le conteneur ne l'expose pas à l'hôte. Ignoré si `MCP_TRANSPORT=stdio`. |
+| `MCP_BEARER_TOKEN` | **requis** | Token attendu dans `Authorization: Bearer <token>` sur `/mcp`. 16 caractères minimum. Toujours requis, même en `stdio` (où il ne sert pas). |
 
 Générer le token avec :
 
@@ -101,13 +112,32 @@ envoyez depuis Mail.
 
 ---
 
+## Attente de nouveaux messages (IDLE)
+
+| Variable | Défaut | Description |
+|---|---|---|
+| `ENABLE_IDLE_WATCH` | `false` | `true` enregistre l'outil `wait_for_new_message` |
+
+**Off par défaut, volontairement.** `wait_for_new_message` ouvre une connexion IMAP dédiée hors du
+pool et attend l'événement `exists` d'iCloud. Cette version n'a **pas de reconnexion** : si la
+connexion iCloud saute pendant l'attente (coupure réseau, throttling, timeout serveur), l'outil ne
+le détecte pas et se contente d'expirer avec `timedOut: true` — un nouveau message arrivé
+entre-temps est manqué **sans le moindre signal**. Tant que la version avec reconnexion n'est pas
+faite ([#20](https://github.com/leolesimple/mail-mcp/issues/20)), l'outil n'est exposé que si vous
+l'activez explicitement, en connaissance de cause.
+
+Reconnus comme « activé » : toute valeur autre que `false`, `0`, `no` (casse et espaces ignorés).
+
+---
+
 ## Logs
 
 | Variable | Défaut | Description |
 |---|---|---|
 | `LOG_LEVEL` | `info` | `fatal`, `error`, `warn`, `info`, `debug`, `trace` |
 
-Logs JSON structurés (pino) sur la sortie standard. Les champs `password`, `pass`,
+Logs JSON structurés (pino), sur **stdout** en transport `http`, sur **stderr** dès que `stdio` est
+actif (stdout y est réservé au JSON-RPC). Les champs `password`, `pass`,
 `ICLOUD_APP_PASSWORD` et `token` sont expurgés automatiquement, et le contenu des mails n'est jamais
 loggé — seulement des métadonnées (dossier, UID, nombre de résultats).
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -93,9 +93,29 @@ Décommenter la section `ports:` du service `mail-mcp` dans `docker-compose.yml`
 
 ---
 
+## Choisir le transport
+
+`MCP_TRANSPORT` (défaut `http`) pilote la façon dont le serveur parle aux clients :
+
+| Valeur | Usage |
+|---|---|
+| `http` | Serveur HTTP streamable — le déploiement de référence ci-dessus (Docker + tunnel). |
+| `stdio` | Serveur JSON-RPC sur stdin/stdout, lancé directement par un client MCP local. Pas de port, pas de token. |
+| `both` | Les deux en parallèle. |
+
+> **En stdio, stdout porte le canal JSON-RPC.** Le serveur bascule alors automatiquement ses logs
+> sur **stderr** (`pino.destination(2)`) : une seule ligne de log sur stdout casserait le cadrage
+> des messages et rendrait le serveur muet, sans erreur visible. Rien à configurer, mais ne pas
+> rediriger stderr vers stdout dans un wrapper.
+
+L'arrêt propre (fermeture des sessions, du pool IMAP, du transport SMTP sur `SIGINT`/`SIGTERM`)
+fonctionne à l'identique dans les trois modes.
+
+---
+
 ## Brancher un client MCP
 
-### Claude Code
+### Claude Code — HTTP (déploiement distant)
 
 ```bash
 claude mcp add --transport http mail-mcp https://mail-mcp.exemple.com/mcp \
@@ -103,7 +123,24 @@ claude mcp add --transport http mail-mcp https://mail-mcp.exemple.com/mcp \
 ```
 
 Vérifier avec `/mcp` dans une session Claude Code : le serveur doit apparaître connecté avec ses
-dix outils.
+outils.
+
+### Claude Code — stdio (exécution locale)
+
+Pour lancer le serveur en local, sans HTTP ni tunnel :
+
+```bash
+claude mcp add mail-mcp -- \
+  env MCP_TRANSPORT=stdio \
+      ICLOUD_EMAIL=vous@icloud.com ICLOUD_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx \
+      MCP_BEARER_TOKEN=$(openssl rand -hex 16) \
+  node /chemin/vers/mail-mcp/dist/index.js
+```
+
+(ou `npx tsx src/index.ts` en développement). Le client démarre le processus lui-même ; `PORT`
+n'est pas utilisé et le `MCP_BEARER_TOKEN` ne sert pas à authentifier (aucune couche HTTP), mais la
+validation de configuration l'exige toujours — n'importe quelle valeur d'au moins 16 caractères
+convient.
 
 ### Claude Desktop / claude.ai
 
@@ -146,3 +183,4 @@ au prochain appel.
 | `502` Cloudflare | Le conteneur `mail-mcp` est arrêté, ou le hostname public pointe vers le mauvais port/nom de service. |
 | Erreurs IMAP intermittentes | Throttling iCloud. Baisser `IMAP_POOL_SIZE`, ou espacer les appels. |
 | Le tunnel ne se connecte pas | `TUNNEL_TOKEN` invalide ou tunnel supprimé côté Cloudflare. |
+| En stdio, le client MCP n'obtient jamais de réponse | Quelque chose écrit sur stdout du processus (wrapper qui fait `2>&1`, `console.log` ajouté, autre lib bavarde). stdout est réservé au JSON-RPC. |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,16 +1,26 @@
 # Référence des outils
 
-Les dix outils exposés par le serveur MCP. Les descriptions transmises à Claude sont en anglais
-(c'est ce que le modèle lit) ; cette page en donne la version détaillée.
+Les dix outils exposés par le serveur MCP (onze avec `wait_for_new_message`, désactivé par
+défaut), plus ses [resources et prompts](#resources-et-prompts). Les descriptions transmises à
+Claude sont en anglais (c'est ce que le modèle lit) ; cette page en donne la version détaillée.
 
 Conventions communes :
+
+- **Sorties structurées.** Chaque outil déclare un `outputSchema` et renvoie sa réponse en
+  `structuredContent` (objet validé contre le schéma) **et** dans un bloc texte JSON (pour les
+  clients qui ne lisent pas le structuré).
+- **Outils qui renvoient une liste** (`list_folders`, `list_messages`, `search_messages`) :
+  `structuredContent` porte **toujours** la forme enveloppée sous une clé (`{ "folders": [...] }`,
+  `{ "messages": [...] }`) — le protocole impose un objet. Le bloc texte, lui, reste le **tableau
+  nu** par défaut ; passer `envelope: true` pour qu'il porte aussi la forme enveloppée.
+- **Erreurs applicatives.** Les validations d'entrée qui échouent (critère de recherche manquant,
+  corps de message vide…) reviennent avec `isError` et un message français, sans `structuredContent`.
 
 - **`folder`** est un chemin IMAP tel que renvoyé par `list_folders` : `INBOX`, `Archive`,
   `Sent Messages`, `Deleted Messages`… Les chemins iCloud contiennent des espaces et sont sensibles
   à la casse.
 - **`uid`** est l'identifiant IMAP d'un message *dans un dossier donné*. Un message qui change de
   dossier change d'UID : toujours re-lister après un `move_message`.
-- Tous les outils renvoient du JSON dans un bloc de texte.
 - Une erreur IMAP/SMTP remonte classifiée, avec un message explicite (voir
   [architecture.md](architecture.md#gestion-des-erreurs)).
 
@@ -20,10 +30,16 @@ Conventions communes :
 
 ### `list_folders`
 
-Liste tous les dossiers IMAP du compte. Aucun paramètre.
+Liste tous les dossiers IMAP du compte.
+
+| Paramètre | Type | Défaut | Description |
+|---|---|---|---|
+| `envelope` | boolean | `false` | Envelopper aussi le bloc texte sous la clé `folders` |
 
 À appeler en premier quand on ne connaît pas les noms exacts des dossiers, notamment pour trouver
 l'archive et la corbeille via leur `specialUse`.
+
+Bloc texte (défaut) — `structuredContent` porte la même liste sous `{ "folders": [...] }` :
 
 ```jsonc
 [
@@ -61,12 +77,15 @@ Liste les messages d'un dossier, **du plus récent au plus ancien**.
 | `before` | string ISO 8601 | — | Messages reçus avant cette date (exclue) |
 | `from` | string | — | Filtre sur l'expéditeur (correspondance partielle, côté serveur) |
 | `limit` | number | `50` | Nombre max de messages (200 maximum) |
+| `envelope` | boolean | `false` | Envelopper aussi le bloc texte sous la clé `messages` |
 
 `since` et `before` acceptent une date seule (`2026-07-01`) ou un instant complet
 (`2026-07-01T08:00:00Z`).
 
 Le filtrage est fait par le serveur IMAP, pas en local : demander les non-lus d'un dossier de
 50 000 messages reste rapide.
+
+Bloc texte (défaut) — `structuredContent` porte la même liste sous `{ "messages": [...] }` :
 
 ```jsonc
 [
@@ -100,6 +119,7 @@ Recherche IMAP native. Les critères fournis sont **combinés en ET**.
 | `from` | string | — | Sous-chaîne dans l'expéditeur |
 | `to` | string | — | Sous-chaîne dans le destinataire |
 | `limit` | number | `50` | Nombre max de résultats (200 maximum) |
+| `envelope` | boolean | `false` | Envelopper aussi le bloc texte sous la clé `messages` |
 
 Retour identique à `list_messages`, trié du plus récent au plus ancien.
 
@@ -110,12 +130,15 @@ IMAP standard. Pour chercher partout, itérer sur `list_folders`.
 
 ### `get_message`
 
-Contenu complet d'un message.
+Contenu complet d'un message, avec **maîtrise de la taille renvoyée**.
 
 | Paramètre | Type | Défaut | Description |
 |---|---|---|---|
 | `folder` | string | `INBOX` | Dossier contenant le message |
 | `uid` | number | *(requis)* | UID IMAP du message |
+| `maxBodyChars` | number | `MAX_BODY_CHARS` (20000) | Longueur max de chaque partie de corps renvoyée |
+| `includeHtml` | boolean | `false` | Inclure la partie HTML brute (volumineuse, hors contexte par défaut) |
+| `includeRawHeaders` | boolean | `false` | Inclure le bloc d'en-têtes brut (`List-Unsubscribe`, DKIM, débogage) |
 
 ```jsonc
 {
@@ -130,15 +153,24 @@ Contenu complet d'un message.
   "size": 24815,
   "messageId": "<abc123@exemple.fr>",     // sert au threading des réponses
   "references": ["<message-precedent@exemple.fr>"],
-  "text": "Bonjour,\n\nVeuillez trouver…",
-  "html": "<html>…</html>",                // `false` si le message n'a pas de partie HTML
+  "text": "Bonjour,\n\nVeuillez trouver…",  // partie texte, ou texte dérivé du HTML si absente
+  "html": false,                            // string seulement si includeHtml: true
+  "bodyTruncated": false,                    // true dès qu'une partie a été coupée à maxBodyChars
   "attachments": [
     { "filename": "facture.pdf", "contentType": "application/pdf", "size": 18234 }
-  ]
+  ],
+  "rawHeaders": "From: …\r\nSubject: …"      // présent seulement si includeRawHeaders: true
 }
 ```
 
-**Le contenu binaire des pièces jointes n'est pas renvoyé**, seulement leurs métadonnées.
+Points clés :
+
+- **`includeHtml` est à `false` par défaut.** Le HTML brut était jusqu'ici déversé intégralement
+  dans le contexte du client — c'était le premier poste de gaspillage du serveur.
+- Si le message n'a **pas de partie texte**, `text` est dérivé du HTML (via `html-to-text`).
+- La troncature est **toujours explicite** : `bodyTruncated: true`, jamais silencieuse.
+- `includeRawHeaders` ne renvoie que le bloc d'en-têtes, **pas** le corps brut.
+- **Le contenu binaire des pièces jointes n'est pas renvoyé**, seulement leurs métadonnées.
 
 Lire un message le marque comme lu du côté iCloud uniquement si le serveur le décide : le dossier
 est ouvert en lecture seule, donc en pratique le flag `\Seen` n'est pas posé. Utiliser
@@ -287,3 +319,65 @@ Les ajouts de flags sont appliqués avant les retraits, quel que soit l'ordre de
 ```jsonc
 { "uid": 10432, "folder": "INBOX", "applied": ["read", "flagged"] }
 ```
+
+---
+
+## Attente
+
+### `wait_for_new_message`
+
+> **Désactivé par défaut.** L'outil n'est enregistré que si `ENABLE_IDLE_WATCH=true` (voir
+> [configuration.md](configuration.md#attente-de-nouveaux-messages-idle)). Sans reconnexion, une
+> coupure iCloud pendant l'attente est manquée silencieusement.
+
+Bloque jusqu'à l'arrivée d'un nouveau message dans un dossier, ou jusqu'à expiration du délai.
+
+| Paramètre | Type | Défaut | Description |
+|---|---|---|---|
+| `folder` | string | `INBOX` | Dossier surveillé |
+| `timeoutSec` | number | `60` | Délai d'attente en secondes (300 maximum) |
+
+Ouvre une connexion IMAP **dédiée, hors du pool** (le pool ne fait que deux connexions et une
+attente longue les monopoliserait), et la referme systématiquement à la fin.
+
+Un délai atteint **n'est pas une erreur** : `timedOut: true` et `newMessages: []`.
+
+```jsonc
+{
+  "folder": "INBOX",
+  "timedOut": false,
+  "newMessages": [
+    { "uid": 10440, "subject": "Nouveau message", "from": [ /* … */ ], "seen": false, "flagged": false }
+  ]
+}
+```
+
+C'est une version minimale du push MCP : pas de reconnexion automatique, pas de notification
+`resources/updated`. Pour un suivi durable, ré-appeler l'outil.
+
+---
+
+## Resources et prompts
+
+En plus des outils, le serveur expose des **resources** (lecture seule, référençables par URI) et
+des **prompts** (points de départ guidés, en français).
+
+### Resources
+
+| URI | Contenu |
+|---|---|
+| `mail://folders` | La liste des dossiers (même donnée que `list_folders`) |
+| `mail://folder/{path}/message/{uid}` | Un message complet (même donnée que `get_message`, sans les options de taille) |
+
+L'argument `{path}` du gabarit propose une **complétion** sur les dossiers du compte (liste mise en
+cache 60 s pour ne pas multiplier les commandes `LIST`).
+
+### Prompts
+
+| Prompt | Arguments | Rôle |
+|---|---|---|
+| `triage-inbox` | `folder?` | Passer en revue les non-lus et proposer une action par message |
+| `summarize-thread` | `folder`, `uid` | Résumer le fil auquel appartient un message |
+| `draft-reply` | `folder`, `uid`, `instructions?` | Rédiger un brouillon de réponse et l'enregistrer (sans l'envoyer) |
+
+L'argument `folder` de chaque prompt propose la même complétion que la resource.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,12 @@
     "": {
       "name": "mail-mcp",
       "version": "0.1.0",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
+        "html-to-text": "10.0.1",
         "imapflow": "^1.4.7",
         "mailparser": "^3.9.14",
         "nodemailer": "^9.0.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
+    "html-to-text": "10.0.1",
     "imapflow": "^1.4.7",
     "mailparser": "^3.9.14",
     "nodemailer": "^9.0.3",

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,0 +1,23 @@
+import { config } from './config.js';
+
+/**
+ * Identité du compte mail, dérivée de la configuration. Point d'accès unique
+ * aux identifiants pour le code qui ouvre une connexion hors des pools
+ * IMAP/SMTP (par exemple la connexion IDLE de `wait_for_new_message`).
+ *
+ * NOTE (lot C) : fichier appartenant au lot 0. Créé ici à l'identique du
+ * contrat pour pouvoir compiler ; la version du lot 0 fait foi au merge.
+ */
+export interface MailAccount {
+  email: string;
+  password: string;
+  imap: { host: string; port: number };
+  smtp: { host: string; port: number };
+}
+
+export const account: MailAccount = {
+  email: config.ICLOUD_EMAIL,
+  password: config.ICLOUD_APP_PASSWORD,
+  imap: { host: config.IMAP_HOST, port: config.IMAP_PORT },
+  smtp: { host: config.SMTP_HOST, port: config.SMTP_PORT },
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,21 @@
 import 'dotenv/config';
 import { z } from 'zod';
 
+/**
+ * Drapeau booléen lu d'une variable d'environnement, tolérant à l'absence.
+ * `"false"`, `"0"`, `"no"` (casse et espaces ignorés) → `false` ; toute autre
+ * valeur non vide → `true` ; absente → `defaultValue`.
+ *
+ * NOTE (lot C) : fonction appartenant au lot 0. Recréée ici à l'identique du
+ * contrat pour compiler `ENABLE_IDLE_WATCH` ; la version du socle fait foi au merge.
+ */
+export function envBool(defaultValue: boolean): z.ZodType<boolean, unknown> {
+  return z.preprocess(
+    (v) => (typeof v === 'string' ? !['false', '0', 'no'].includes(v.trim().toLowerCase()) : defaultValue),
+    z.boolean(),
+  );
+}
+
 const envSchema = z.object({
   ICLOUD_EMAIL: z.string().email('ICLOUD_EMAIL doit être une adresse email valide'),
   ICLOUD_APP_PASSWORD: z.string().min(1, 'ICLOUD_APP_PASSWORD est requis'),
@@ -13,6 +28,18 @@ const envSchema = z.object({
   MCP_BEARER_TOKEN: z.string().min(16, 'MCP_BEARER_TOKEN doit faire au moins 16 caractères'),
   PORT: z.coerce.number().int().positive().default(3000),
   LOG_LEVEL: z.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace']).default('info'),
+  // Transport MCP. `http` : serveur HTTP streamable (défaut historique).
+  // `stdio` : serveur JSON-RPC sur stdin/stdout (branchement local d'un client).
+  // `both` : les deux en parallèle. En stdio, le logger bascule sur stderr
+  // (voir src/logger.ts) pour ne pas corrompre le canal JSON-RPC.
+  MCP_TRANSPORT: z.enum(['http', 'stdio', 'both']).default('http'),
+  // Plafond par défaut de la taille du corps renvoyé par get_message, en
+  // caractères. Surcharger par appel via le paramètre `maxBodyChars`.
+  MAX_BODY_CHARS: z.coerce.number().int().positive().default(20000),
+  // Active l'outil wait_for_new_message (attente IDLE sur connexion hors pool).
+  // OFF par défaut : pas de reconnexion, l'attente se dégrade silencieusement
+  // si la connexion iCloud saute. Voir docs/configuration.md.
+  ENABLE_IDLE_WATCH: envBool(false),
   // Coupe-circuit pour send_message / reply_message. Volontairement pas un simple
   // z.coerce.boolean() : dans zod, "false" est une chaîne non-vide donc coercée à `true`.
   ENABLE_SENDING: z

--- a/src/imap/idle.ts
+++ b/src/imap/idle.ts
@@ -1,0 +1,80 @@
+import { ImapFlow } from 'imapflow';
+import type { ExistsEvent } from 'imapflow';
+import { account } from '../account.js';
+import { classifyImapError } from './errors.js';
+import { toSummary } from './messages.js';
+import type { MessageSummary } from './messages.js';
+import { logger } from '../logger.js';
+
+const log = logger.child({ module: 'imap-idle' });
+
+/** Plafond dur du délai d'attente : une connexion hors pool ne doit jamais rester ouverte indéfiniment. */
+export const MAX_WAIT_SECONDS = 300;
+
+export interface WaitForNewMessageResult {
+  folder: string;
+  timedOut: boolean;
+  newMessages: MessageSummary[];
+}
+
+/** Borne le délai demandé dans `[1, MAX_WAIT_SECONDS]`. */
+export function boundTimeout(seconds: number): number {
+  if (!Number.isFinite(seconds)) return 1;
+  return Math.min(Math.max(1, Math.floor(seconds)), MAX_WAIT_SECONDS);
+}
+
+/**
+ * Attend l'arrivée d'un nouveau message dans `folder`, jusqu'à `timeoutSec`
+ * secondes. Ouvre une connexion IMAP **hors du pool** (le pool ne fait que 2
+ * connexions et IDLE les monopolise), et la referme systématiquement.
+ *
+ * Version minimale du push MCP : pas de reconnexion, pas de `resources/updated`.
+ * Un timeout atteint n'est pas une erreur (`timedOut: true`).
+ */
+export async function waitForNewMessage(folder: string, timeoutSec: number): Promise<WaitForNewMessageResult> {
+  const bounded = boundTimeout(timeoutSec);
+  const client = new ImapFlow({
+    host: account.imap.host,
+    port: account.imap.port,
+    secure: true,
+    auth: { user: account.email, pass: account.password },
+    logger: false,
+  });
+
+  try {
+    await client.connect();
+    const mailbox = await client.mailboxOpen(folder, { readOnly: true });
+    const startExists = mailbox.exists;
+
+    const finalCount = await new Promise<number | null>((resolve) => {
+      const timer = setTimeout(() => resolve(null), bounded * 1000);
+      client.on('exists', (data: ExistsEvent) => {
+        if (data.path === folder && data.count > startExists) {
+          clearTimeout(timer);
+          resolve(data.count);
+        }
+      });
+    });
+
+    if (finalCount === null) {
+      return { folder, timedOut: true, newMessages: [] };
+    }
+
+    const fetched = await client.fetchAll(`${startExists + 1}:*`, {
+      uid: true,
+      envelope: true,
+      flags: true,
+      size: true,
+    });
+    return { folder, timedOut: false, newMessages: fetched.map(toSummary) };
+  } catch (err) {
+    throw classifyImapError(err);
+  } finally {
+    try {
+      await client.logout();
+    } catch {
+      client.close();
+    }
+    log.debug({ folder }, 'idle connection closed');
+  }
+}

--- a/src/imap/messages.ts
+++ b/src/imap/messages.ts
@@ -110,6 +110,27 @@ export async function searchMessages(folder: string, options: SearchMessagesOpti
   return withMailbox(folder, (client) => fetchSummaries(client, query, options.limit), { readOnly: true });
 }
 
+/**
+ * Source RFC 5322 brute d'un message (en-têtes + corps), telle quelle.
+ *
+ * NOTE (lot C) : fonction appartenant au lot A. Créée ici à l'identique du
+ * contrat (fetch `{ source: true }`, comme `getMessage`) pour pouvoir compiler
+ * `get_message` avec `includeRawHeaders` ; la version du lot A fait foi au merge.
+ */
+export async function getMessageSource(folder: string, uid: number): Promise<Buffer> {
+  return withMailbox(
+    folder,
+    async (client) => {
+      const fetched = await client.fetchOne(uid, { uid: true, source: true }, { uid: true });
+      if (!fetched || !fetched.source) {
+        throw new Error(`Message UID ${uid} introuvable dans "${folder}"`);
+      }
+      return fetched.source;
+    },
+    { readOnly: true },
+  );
+}
+
 export async function getMessage(folder: string, uid: number): Promise<FullMessage> {
   return withMailbox(
     folder,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,44 @@
+import type { Server } from 'node:http';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { createHttpServer, closeAllSessions } from './http/server.js';
+import { createMailMcpServer } from './mcp/server.js';
 import { imapPool } from './imap/pool.js';
 import { closeSmtp } from './smtp/client.js';
 import { config } from './config.js';
 import { logger } from './logger.js';
 
-const app = createHttpServer();
+// C1 — transport MCP sélectionnable. Le montage HTTP est conditionnel : en
+// `stdio` pur il n'y a pas de serveur HTTP à démarrer ni à fermer.
+const useHttp = config.MCP_TRANSPORT === 'http' || config.MCP_TRANSPORT === 'both';
+const useStdio = config.MCP_TRANSPORT === 'stdio' || config.MCP_TRANSPORT === 'both';
 
-const server = app.listen(config.PORT, '0.0.0.0', () => {
-  logger.info({ port: config.PORT }, 'mail-mcp http server listening');
-});
+const cleanups: Array<() => void | Promise<void>> = [];
+
+if (useHttp) {
+  const app = createHttpServer();
+  const httpServer: Server = app.listen(config.PORT, '0.0.0.0', () => {
+    logger.info({ port: config.PORT }, 'mail-mcp http server listening');
+  });
+  cleanups.push(() => {
+    httpServer.close();
+  });
+  cleanups.push(closeAllSessions);
+}
+
+if (useStdio) {
+  const server = createMailMcpServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  cleanups.push(() => transport.close());
+  // stderr : en stdio, stdout est le canal JSON-RPC (voir src/logger.ts).
+  logger.info('mail-mcp stdio server ready');
+}
 
 async function shutdown(signal: string): Promise<void> {
   logger.info({ signal }, 'shutting down');
-  server.close();
-  await closeAllSessions();
+  for (const cleanup of cleanups) {
+    await cleanup();
+  }
   await imapPool.close();
   closeSmtp();
   process.exit(0);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,11 +1,26 @@
 import pino from 'pino';
 import { config } from './config.js';
 
-export const logger = pino({
-  level: config.LOG_LEVEL,
-  timestamp: pino.stdTimeFunctions.isoTime,
-  redact: {
-    paths: ['*.password', '*.pass', '*.ICLOUD_APP_PASSWORD', '*.token'],
-    censor: '[redacted]',
+/**
+ * Descripteur de fichier vers lequel écrire les logs.
+ *
+ * En transport stdio, stdout porte le canal JSON-RPC : la moindre ligne de log
+ * qui y atterrit casse le cadrage des messages et rend le serveur inutilisable
+ * de façon difficile à diagnostiquer. Dès que stdio est actif (`stdio` ou
+ * `both`), les logs partent donc sur stderr (fd 2).
+ */
+export function logStreamFd(transport: string): 1 | 2 {
+  return transport === 'stdio' || transport === 'both' ? 2 : 1;
+}
+
+export const logger = pino(
+  {
+    level: config.LOG_LEVEL,
+    timestamp: pino.stdTimeFunctions.isoTime,
+    redact: {
+      paths: ['*.password', '*.pass', '*.ICLOUD_APP_PASSWORD', '*.token'],
+      censor: '[redacted]',
+    },
   },
-});
+  pino.destination(logStreamFd(config.MCP_TRANSPORT)),
+);

--- a/src/mcp/folder-cache.ts
+++ b/src/mcp/folder-cache.ts
@@ -1,0 +1,70 @@
+import { listFolders } from '../imap/folders.js';
+
+/**
+ * Cache court de la liste des chemins de dossiers, pour la complétion de
+ * l'argument `folder` (prompts et resources). Sans lui, chaque frappe de
+ * l'utilisateur déclencherait une commande IMAP LIST sur un pool de 2
+ * connexions.
+ */
+
+const DEFAULT_TTL_MS = 60_000;
+
+export interface FolderCache {
+  paths(): Promise<string[]>;
+  reset(): void;
+}
+
+export function createFolderCache(
+  load: () => Promise<string[]>,
+  ttlMs: number = DEFAULT_TTL_MS,
+  now: () => number = Date.now,
+): FolderCache {
+  let entry: { paths: string[]; at: number } | undefined;
+  let inflight: Promise<string[]> | undefined;
+
+  return {
+    async paths() {
+      if (entry && now() - entry.at < ttlMs) {
+        return entry.paths;
+      }
+      if (!inflight) {
+        inflight = load()
+          .then((paths) => {
+            entry = { paths, at: now() };
+            return paths;
+          })
+          .finally(() => {
+            inflight = undefined;
+          });
+      }
+      return inflight;
+    },
+    reset() {
+      entry = undefined;
+      inflight = undefined;
+    },
+  };
+}
+
+/** Filtre la liste des dossiers sur la saisie en cours (sous-chaîne, casse ignorée). */
+export function filterFolderPaths(paths: string[], value: string, limit = 100): string[] {
+  const needle = value.trim().toLowerCase();
+  const matched = needle ? paths.filter((path) => path.toLowerCase().includes(needle)) : paths;
+  return matched.slice(0, limit);
+}
+
+const folderCache = createFolderCache(() => listFolders().then((folders) => folders.map((folder) => folder.path)));
+
+/**
+ * Callback de complétion pour un argument `folder`. Ne remonte jamais d'erreur :
+ * une complétion est un confort, pas une opération critique.
+ */
+export async function completeFolder(value: string): Promise<string[]> {
+  const paths = await folderCache.paths().catch(() => [] as string[]);
+  return filterFolderPaths(paths, value);
+}
+
+/** Vide le cache du module (tests). */
+export function resetFolderCache(): void {
+  folderCache.reset();
+}

--- a/src/mcp/message-content.ts
+++ b/src/mcp/message-content.ts
@@ -1,0 +1,80 @@
+import { convert } from 'html-to-text';
+import type { FullMessage } from '../imap/messages.js';
+
+/**
+ * Mise en forme du corps d'un message pour la réponse MCP : conversion
+ * HTML → texte quand la partie texte manque, et surtout maîtrise de la taille
+ * — aujourd'hui `get_message` déverse le corps entier (texte ET HTML brut)
+ * dans le contexte du client, ce qui est le premier poste de gaspillage.
+ */
+
+export interface BodyOptions {
+  /** Longueur max, en caractères, de chaque partie renvoyée. */
+  maxBodyChars: number;
+  /** Inclure la partie HTML brute. `false` par défaut côté outil. */
+  includeHtml: boolean;
+}
+
+export interface PreparedBody {
+  /** Corps texte (issu de la partie texte, ou converti depuis le HTML). */
+  text?: string;
+  /** Partie HTML si `includeHtml`, sinon `false`. */
+  html: string | false;
+  /** `true` dès qu'une partie a été coupée : la troncature n'est jamais silencieuse. */
+  bodyTruncated: boolean;
+}
+
+const HTML_TO_TEXT_OPTIONS: Record<string, unknown> = { wordwrap: false };
+
+/** Convertit une partie HTML en texte lisible. */
+export function htmlToPlainText(html: string): string {
+  return convert(html, HTML_TO_TEXT_OPTIONS).trim();
+}
+
+function truncate(value: string, max: number): { value: string; truncated: boolean } {
+  return value.length <= max ? { value, truncated: false } : { value: value.slice(0, max), truncated: true };
+}
+
+export function prepareMessageBody(
+  message: Pick<FullMessage, 'text' | 'html'>,
+  options: BodyOptions,
+): PreparedBody {
+  const rawText = message.text ?? (message.html ? htmlToPlainText(message.html) : undefined);
+
+  let bodyTruncated = false;
+
+  let text: string | undefined;
+  if (rawText !== undefined) {
+    const cut = truncate(rawText, options.maxBodyChars);
+    text = cut.value;
+    bodyTruncated ||= cut.truncated;
+  }
+
+  let html: string | false = false;
+  if (options.includeHtml && message.html) {
+    const cut = truncate(message.html, options.maxBodyChars);
+    html = cut.value;
+    bodyTruncated ||= cut.truncated;
+  }
+
+  return { text, html, bodyTruncated };
+}
+
+/**
+ * Bloc d'en-têtes brut d'un message RFC 5322 : tout jusqu'à la première ligne
+ * vide, corps exclu. Utile pour `List-Unsubscribe`, la signature DKIM, ou le
+ * débogage d'un message mal rendu.
+ */
+export function extractRawHeaders(source: Buffer | string): string {
+  const text = typeof source === 'string' ? source : source.toString('utf8');
+  const crlf = text.indexOf('\r\n\r\n');
+  const lf = text.indexOf('\n\n');
+
+  if (crlf !== -1 && (lf === -1 || crlf < lf)) {
+    return text.slice(0, crlf);
+  }
+  if (lf !== -1) {
+    return text.slice(0, lf);
+  }
+  return text.trimEnd();
+}

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { completable } from '@modelcontextprotocol/sdk/server/completable.js';
+import { completeFolder } from './folder-cache.js';
+
+/**
+ * Prompts MCP : des points de départ courts, en français, pour les tâches
+ * courantes sur une boîte mail. Ils décrivent la marche à suivre avec les
+ * outils du serveur ; ils ne font rien par eux-mêmes.
+ */
+
+// `completable()` marque le schéma en place (propriété non énumérable) et
+// renvoie la même instance : toute méthode zod appelée ensuite (`.describe`…)
+// en produit un clone qui perd la marque. On décrit donc AVANT d'envelopper.
+const folderArg = (description: string) =>
+  completable(z.string().describe(description), (value) => completeFolder(value));
+
+function userText(text: string) {
+  return { messages: [{ role: 'user' as const, content: { type: 'text' as const, text } }] };
+}
+
+export function registerMailPrompts(server: McpServer): void {
+  server.registerPrompt(
+    'triage-inbox',
+    {
+      title: 'Trier la boîte de réception',
+      description: 'Passe en revue les messages non lus et propose une action pour chacun.',
+      argsSchema: {
+        folder: completable(z.string().optional(), (value) => completeFolder(value ?? '')),
+      },
+    },
+    ({ folder }) =>
+      userText(
+        `Trie le dossier « ${folder ?? 'INBOX'} ».\n\n` +
+          `1. Appelle list_messages avec unreadOnly: true.\n` +
+          `2. Pour chaque message, résume-le en une phrase et recommande UNE action : ` +
+          `répondre, archiver (move_message), supprimer (delete_message), ou laisser tel quel.\n` +
+          `3. Présente le tout sous forme de tableau et attends ma validation avant toute modification.`,
+      ),
+  );
+
+  server.registerPrompt(
+    'summarize-thread',
+    {
+      title: 'Résumer un fil de discussion',
+      description: 'Résume le fil auquel appartient un message donné.',
+      argsSchema: {
+        folder: folderArg('Dossier contenant le message'),
+        uid: z.string().describe('UID IMAP du message'),
+      },
+    },
+    ({ folder, uid }) =>
+      userText(
+        `Résume le fil de discussion contenant le message UID ${uid} du dossier « ${folder} ».\n\n` +
+          `Récupère le message avec get_message. Si son champ References pointe vers d'autres messages ` +
+          `du même dossier, récupère-les aussi via search_messages pour reconstituer le fil.\n` +
+          `Donne-moi : les points clés, les décisions prises, et ce qui attend une réponse de ma part.`,
+      ),
+  );
+
+  server.registerPrompt(
+    'draft-reply',
+    {
+      title: 'Préparer une réponse',
+      description: 'Rédige un brouillon de réponse à un message et l’enregistre (sans l’envoyer).',
+      argsSchema: {
+        folder: folderArg('Dossier contenant le message d’origine'),
+        uid: z.string().describe('UID IMAP du message auquel répondre'),
+        instructions: z.string().optional().describe('Consignes sur le ton ou le contenu de la réponse'),
+      },
+    },
+    ({ folder, uid, instructions }) =>
+      userText(
+        `Prépare une réponse au message UID ${uid} du dossier « ${folder} ».\n\n` +
+          `1. Lis le message avec get_message.\n` +
+          `2. Rédige une réponse en français, concise et polie` +
+          (instructions ? `, en tenant compte de : ${instructions}` : '') +
+          `.\n` +
+          `3. Enregistre-la avec save_draft en renseignant replyFolder et replyUid pour garder le fil. ` +
+          `Ne l'envoie pas : je la relirai depuis mon client mail.`,
+      ),
+  );
+}

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -1,0 +1,62 @@
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { listFolders } from '../imap/folders.js';
+import { getMessage } from '../imap/messages.js';
+import { completeFolder } from './folder-cache.js';
+import { logger } from '../logger.js';
+
+const log = logger.child({ module: 'resources' });
+
+/**
+ * Resources MCP en lecture seule :
+ *   - `mail://folders`                              → la liste des dossiers ;
+ *   - `mail://folder/{path}/message/{uid}`          → un message complet.
+ *
+ * Elles doublent `list_folders` / `get_message` pour les clients qui préfèrent
+ * référencer une ressource (mention @, pièce jointe de contexte) plutôt que
+ * d'appeler un outil.
+ */
+export function registerMailResources(server: McpServer): void {
+  server.registerResource(
+    'folders',
+    'mail://folders',
+    {
+      title: 'Dossiers IMAP',
+      description: 'La liste des dossiers du compte iCloud Mail (chemin, rôle spécial, abonnement).',
+      mimeType: 'application/json',
+    },
+    async (uri) => {
+      log.info('reading folders resource');
+      const folders = await listFolders();
+      return {
+        contents: [{ uri: uri.href, mimeType: 'application/json', text: JSON.stringify(folders, null, 2) }],
+      };
+    },
+  );
+
+  server.registerResource(
+    'message',
+    new ResourceTemplate('mail://folder/{+path}/message/{uid}', {
+      list: undefined,
+      complete: {
+        path: (value) => completeFolder(value),
+      },
+    }),
+    {
+      title: 'Message',
+      description: 'Un message complet, désigné par le chemin de son dossier et son UID IMAP.',
+      mimeType: 'application/json',
+    },
+    async (uri, variables) => {
+      const path = decodeURIComponent(String(variables.path));
+      const uid = Number(variables.uid);
+      if (!Number.isInteger(uid) || uid <= 0) {
+        throw new Error(`UID invalide dans l'URI de ressource : ${String(variables.uid)}`);
+      }
+      log.info({ path, uid }, 'reading message resource');
+      const message = await getMessage(path, uid);
+      return {
+        contents: [{ uri: uri.href, mimeType: 'application/json', text: JSON.stringify(message, null, 2) }],
+      };
+    },
+  );
+}

--- a/src/mcp/result.ts
+++ b/src/mcp/result.ts
@@ -1,0 +1,71 @@
+import type { z } from 'zod';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * Résultat d'outil MCP.
+ *
+ * NOTE (lot C) : fichier appartenant au lot 0. Le lot C y ajoute le support
+ * des sorties structurées (`structuredContent`) ; la version du lot 0 fait foi
+ * au merge, ce fichier ne doit pas diverger de la signature du contrat.
+ */
+
+/**
+ * Sérialise `data` dans un bloc texte (pour les clients qui ne lisent que le
+ * texte) et, si un `schema` est fourni, l'attache aussi en `structuredContent`.
+ *
+ * Le `schema` passé ici doit être le même `outputSchema` que celui déclaré sur
+ * l'outil : le SDK MCP valide `structuredContent` contre lui à l'émission.
+ */
+export function jsonResult(data: unknown, schema?: z.ZodType): CallToolResult {
+  const result: CallToolResult = {
+    content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
+  };
+  if (schema) {
+    result.structuredContent = data as CallToolResult['structuredContent'];
+  }
+  return result;
+}
+
+/**
+ * Résultat d'un outil qui renvoie une liste.
+ *
+ * `structuredContent` porte TOUJOURS la forme enveloppée (`{ [key]: items }`,
+ * plus `nextCursor` s'il y en a un) : le protocole MCP impose un objet, pas un
+ * tableau nu.
+ *
+ * Le bloc texte, lui, reste le **tableau nu par défaut** (contrat historique
+ * des outils). Il passe à la forme enveloppée seulement si `envelope: true`,
+ * ou — quoi qu'il arrive — dès qu'un `nextCursor` est présent : sinon le
+ * curseur de pagination serait invisible pour un client qui ne lit pas le
+ * structuré.
+ *
+ * NOTE MERGE (lot B) : la pagination (`nextCursor`) n'existe pas dans cette
+ * branche. Le paramètre `nextCursor` ci-dessous est le point de branchement :
+ * le lot B le renseignera depuis `list_messages`, et pensera à ajouter
+ * `nextCursor` à l'`outputSchema` correspondant.
+ */
+export function listResult<T>(
+  key: string,
+  items: T[],
+  options: { envelope?: boolean; nextCursor?: string } = {},
+): CallToolResult {
+  const enveloped: Record<string, unknown> = { [key]: items };
+  if (options.nextCursor !== undefined) {
+    enveloped.nextCursor = options.nextCursor;
+  }
+
+  const textPayload = options.envelope || options.nextCursor !== undefined ? enveloped : items;
+
+  return {
+    content: [{ type: 'text', text: JSON.stringify(textPayload, null, 2) }],
+    structuredContent: enveloped as CallToolResult['structuredContent'],
+  };
+}
+
+/** Résultat d'erreur : message utilisateur (français) dans un bloc texte, `isError` posé. */
+export function errorResult(message: string): CallToolResult {
+  return {
+    isError: true,
+    content: [{ type: 'text', text: message }],
+  };
+}

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -1,0 +1,146 @@
+import { z } from 'zod';
+import type { FullMessage, MessageAddress, MessageAttachment, MessageSummary } from '../imap/messages.js';
+import type { FolderInfo } from '../imap/folders.js';
+import type { DeleteResult, FlagResult, MoveResult } from '../imap/mutations.js';
+import type { SendResult } from '../smtp/client.js';
+import type { DraftResult } from '../imap/drafts.js';
+
+/**
+ * Schémas de sortie (`outputSchema`) des outils MCP.
+ *
+ * Ils sont *dérivés* des types déjà définis dans la couche IMAP/SMTP, pas
+ * redécrits : `schemaFor<T>()(...)` échoue à la compilation si un schéma ne
+ * produit plus une valeur assignable à son type source. Quand un de ces types
+ * change, le `typecheck` casse ici — c'est voulu.
+ *
+ * Les lots A et B ajoutent des outils et modifient des formes de retour :
+ * `objectResultSchema` / `listResultSchema` sont là pour qu'ils déclarent
+ * leurs propres schémas sans réécrire ce fumble d'`outputSchema`.
+ */
+
+/** Contraint `schema` à produire un `T` (assignabilité vérifiée à la compilation). */
+export function schemaFor<T>() {
+  return <S extends z.ZodType<T>>(schema: S): S => schema;
+}
+
+/** Enveloppe un schéma d'objet en `outputSchema` (le SDK exige un objet racine). */
+export function objectResultSchema<S extends z.ZodRawShape>(shape: S) {
+  return z.object(shape);
+}
+
+/** `outputSchema` d'un outil qui renvoie une liste, sous la clé `key`. */
+export function listResultSchema<K extends string, S extends z.ZodTypeAny>(key: K, item: S) {
+  return z.object({ [key]: z.array(item) } as Record<K, z.ZodArray<S>>);
+}
+
+export const messageAddressSchema = schemaFor<MessageAddress>()(
+  z.object({
+    name: z.string().optional(),
+    address: z.string().optional(),
+  }),
+);
+
+export const messageAttachmentSchema = schemaFor<MessageAttachment>()(
+  z.object({
+    filename: z.string().optional(),
+    contentType: z.string(),
+    size: z.number(),
+    contentId: z.string().optional(),
+  }),
+);
+
+export const messageSummarySchema = schemaFor<MessageSummary>()(
+  z.object({
+    uid: z.number(),
+    subject: z.string().optional(),
+    from: z.array(messageAddressSchema),
+    to: z.array(messageAddressSchema),
+    date: z.string().optional(),
+    seen: z.boolean(),
+    flagged: z.boolean(),
+    size: z.number().optional(),
+  }),
+);
+
+/** `get_message` : message complet + drapeau de troncature + en-têtes bruts optionnels. */
+export interface GetMessageResult extends FullMessage {
+  bodyTruncated: boolean;
+  rawHeaders?: string;
+}
+
+export const getMessageResultSchema = schemaFor<GetMessageResult>()(
+  z.object({
+    ...messageSummarySchema.shape,
+    cc: z.array(messageAddressSchema),
+    messageId: z.string().optional(),
+    references: z.array(z.string()),
+    text: z.string().optional(),
+    html: z.union([z.string(), z.literal(false)]),
+    attachments: z.array(messageAttachmentSchema),
+    bodyTruncated: z.boolean(),
+    rawHeaders: z.string().optional(),
+  }),
+);
+
+export const folderInfoSchema = schemaFor<FolderInfo>()(
+  z.object({
+    path: z.string(),
+    name: z.string(),
+    delimiter: z.string(),
+    parentPath: z.string(),
+    specialUse: z.string().optional(),
+    flags: z.array(z.string()),
+    subscribed: z.boolean(),
+  }),
+);
+
+export const listFoldersResultSchema = z.object({ folders: z.array(folderInfoSchema) });
+export const listMessagesResultSchema = z.object({ messages: z.array(messageSummarySchema) });
+export const searchMessagesResultSchema = listMessagesResultSchema;
+
+export const moveResultSchema = schemaFor<MoveResult>()(
+  z.object({
+    uid: z.number(),
+    from: z.string(),
+    to: z.string(),
+    newUid: z.number().optional(),
+  }),
+);
+
+export const deleteResultSchema = schemaFor<DeleteResult>()(
+  z.object({
+    uid: z.number(),
+    folder: z.string(),
+    action: z.enum(['moved_to_trash', 'expunged']),
+    destination: z.string().optional(),
+  }),
+);
+
+export const flagResultSchema = schemaFor<FlagResult>()(
+  z.object({
+    uid: z.number(),
+    folder: z.string(),
+    applied: z.array(z.enum(['read', 'unread', 'flagged', 'unflagged'])),
+  }),
+);
+
+export const sendResultSchema = schemaFor<SendResult>()(
+  z.object({
+    messageId: z.string(),
+    accepted: z.array(z.string()),
+    rejected: z.array(z.string()),
+  }),
+);
+
+export const draftResultSchema = schemaFor<DraftResult>()(
+  z.object({
+    folder: z.string(),
+    uid: z.number().optional(),
+  }),
+);
+
+export const waitForNewMessageResultSchema = z.object({
+  folder: z.string(),
+  timedOut: z.boolean(),
+  newMessages: z.array(messageSummarySchema),
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -9,6 +9,10 @@ import { registerMoveMessageTool } from './tools/move-message.js';
 import { registerDeleteMessageTool } from './tools/delete-message.js';
 import { registerFlagMessageTool } from './tools/flag-message.js';
 import { registerSaveDraftTool } from './tools/save-draft.js';
+import { registerWaitForNewMessageTool } from './tools/wait-for-new-message.js';
+import { registerMailResources } from './resources.js';
+import { registerMailPrompts } from './prompts.js';
+import { config } from '../config.js';
 
 export function createMailMcpServer(): McpServer {
   const server = new McpServer({
@@ -26,6 +30,15 @@ export function createMailMcpServer(): McpServer {
   registerDeleteMessageTool(server);
   registerFlagMessageTool(server);
   registerSaveDraftTool(server);
+
+  // wait_for_new_message reste derrière un flag (défaut OFF) : sans reconnexion,
+  // l'attente IDLE se dégrade silencieusement si la connexion iCloud saute (#20).
+  if (config.ENABLE_IDLE_WATCH) {
+    registerWaitForNewMessageTool(server);
+  }
+
+  registerMailResources(server);
+  registerMailPrompts(server);
 
   return server;
 }

--- a/src/mcp/tools/delete-message.ts
+++ b/src/mcp/tools/delete-message.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { deleteMessage } from '../../imap/mutations.js';
+import { deleteResultSchema } from '../schemas.js';
+import { jsonResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'delete_message' });
@@ -17,11 +19,12 @@ export function registerDeleteMessageTool(server: McpServer): void {
         folder: z.string().min(1),
         uid: z.coerce.number().int().positive(),
       },
+      outputSchema: deleteResultSchema.shape,
     },
     async ({ folder, uid }) => {
       log.info({ folder, uid }, 'deleting message');
       const result = await deleteMessage(folder, uid);
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      return jsonResult(result, deleteResultSchema);
     },
   );
 }

--- a/src/mcp/tools/flag-message.ts
+++ b/src/mcp/tools/flag-message.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { flagMessage } from '../../imap/mutations.js';
+import { flagResultSchema } from '../schemas.js';
+import { jsonResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'flag_message' });
@@ -19,11 +21,12 @@ export function registerFlagMessageTool(server: McpServer): void {
           .min(1)
           .describe('One or more flag changes to apply'),
       },
+      outputSchema: flagResultSchema.shape,
     },
     async ({ folder, uid, actions }) => {
       log.info({ folder, uid, actions }, 'flagging message');
       const result = await flagMessage(folder, uid, actions);
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      return jsonResult(result, flagResultSchema);
     },
   );
 }

--- a/src/mcp/tools/get-message.ts
+++ b/src/mcp/tools/get-message.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { getMessage } from '../../imap/messages.js';
+import { getMessage, getMessageSource } from '../../imap/messages.js';
+import { extractRawHeaders, prepareMessageBody } from '../message-content.js';
+import { getMessageResultSchema } from '../schemas.js';
+import { jsonResult } from '../result.js';
+import { config } from '../../config.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'get_message' });
@@ -11,17 +15,50 @@ export function registerGetMessageTool(server: McpServer): void {
     {
       title: 'Get message',
       description:
-        'Fetches the full content of a message by UID: headers, text/HTML body, and attachment metadata ' +
-        '(attachment binary content is not included).',
+        'Fetches the full content of a message by UID: headers, plain-text body, and attachment metadata. ' +
+        'The body is truncated to maxBodyChars (bodyTruncated flags it). The raw HTML body is omitted unless ' +
+        'includeHtml is true. When the message has no text part, the body is derived from its HTML. ' +
+        'Attachment binary content is never included.',
       inputSchema: {
         folder: z.string().min(1).default('INBOX'),
         uid: z.coerce.number().int().positive().describe('IMAP UID of the message'),
+        maxBodyChars: z.coerce
+          .number()
+          .int()
+          .positive()
+          .max(200_000)
+          .default(config.MAX_BODY_CHARS)
+          .describe('Truncate each returned body part to this many characters'),
+        includeHtml: z
+          .boolean()
+          .default(false)
+          .describe('Include the raw HTML body (large; kept out of context by default)'),
+        includeRawHeaders: z
+          .boolean()
+          .default(false)
+          .describe('Include the raw RFC 5322 header block (List-Unsubscribe, DKIM, debugging)'),
       },
+      outputSchema: getMessageResultSchema.shape,
     },
-    async ({ folder, uid }) => {
-      log.info({ folder, uid }, 'fetching message');
+    async ({ folder, uid, maxBodyChars, includeHtml, includeRawHeaders }) => {
+      log.info({ folder, uid, includeHtml, includeRawHeaders }, 'fetching message');
       const message = await getMessage(folder, uid);
-      return { content: [{ type: 'text', text: JSON.stringify(message, null, 2) }] };
+      const { text, html, bodyTruncated } = prepareMessageBody(message, { maxBodyChars, includeHtml });
+
+      const rawHeaders = includeRawHeaders
+        ? extractRawHeaders(await getMessageSource(folder, uid))
+        : undefined;
+
+      return jsonResult(
+        {
+          ...message,
+          text,
+          html,
+          bodyTruncated,
+          ...(rawHeaders !== undefined ? { rawHeaders } : {}),
+        },
+        getMessageResultSchema,
+      );
     },
   );
 }

--- a/src/mcp/tools/list-folders.ts
+++ b/src/mcp/tools/list-folders.ts
@@ -1,5 +1,8 @@
+import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { listFolders } from '../../imap/folders.js';
+import { listFoldersResultSchema } from '../schemas.js';
+import { listResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'list_folders' });
@@ -10,19 +13,20 @@ export function registerListFoldersTool(server: McpServer): void {
     {
       title: 'List mail folders',
       description:
-        'Lists all IMAP folders in the iCloud Mail account (INBOX, Sent, Archive, Trash, and any custom folders).',
+        'Lists all IMAP folders in the iCloud Mail account (INBOX, Sent, Archive, Trash, and any custom folders). ' +
+        'The text block is a bare array; structuredContent wraps it under a "folders" key.',
+      inputSchema: {
+        envelope: z
+          .boolean()
+          .default(false)
+          .describe('Wrap the text block under a "folders" key too (structuredContent always is)'),
+      },
+      outputSchema: listFoldersResultSchema.shape,
     },
-    async () => {
+    async ({ envelope }) => {
       log.info('listing folders');
       const folders = await listFolders();
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(folders, null, 2),
-          },
-        ],
-      };
+      return listResult('folders', folders, { envelope });
     },
   );
 }

--- a/src/mcp/tools/list-messages.ts
+++ b/src/mcp/tools/list-messages.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { listMessages } from '../../imap/messages.js';
+import { listMessagesResultSchema } from '../schemas.js';
+import { listResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'list_messages' });
@@ -15,9 +17,14 @@ export function registerListMessagesTool(server: McpServer): void {
     {
       title: 'List messages',
       description:
-        'Lists messages in an IMAP folder, optionally filtered by read status, date range, or sender. Returns newest messages first.',
+        'Lists messages in an IMAP folder, optionally filtered by read status, date range, or sender. ' +
+        'Newest first. The text block is a bare array; structuredContent wraps it under a "messages" key.',
       inputSchema: {
         folder: z.string().min(1).default('INBOX').describe('Folder path, e.g. "INBOX", "Archive"'),
+        envelope: z
+          .boolean()
+          .default(false)
+          .describe('Wrap the text block under a "messages" key too (structuredContent always is)'),
         unreadOnly: z.boolean().optional().describe('Only return unread messages'),
         since: isoDate.optional().describe('Only messages received on or after this date (ISO 8601, e.g. "2026-07-01")'),
         before: isoDate.optional().describe('Only messages received before this date (ISO 8601)'),
@@ -30,8 +37,9 @@ export function registerListMessagesTool(server: McpServer): void {
           .default(50)
           .describe('Max number of messages to return (newest first)'),
       },
+      outputSchema: listMessagesResultSchema.shape,
     },
-    async ({ folder, unreadOnly, since, before, from, limit }) => {
+    async ({ folder, unreadOnly, since, before, from, limit, envelope }) => {
       log.info({ folder, unreadOnly, limit }, 'listing messages');
       const messages = await listMessages(folder, {
         unreadOnly,
@@ -40,7 +48,8 @@ export function registerListMessagesTool(server: McpServer): void {
         from,
         limit,
       });
-      return { content: [{ type: 'text', text: JSON.stringify(messages, null, 2) }] };
+      // NOTE MERGE (lot B) : passer ici `nextCursor` de la pagination à listResult.
+      return listResult('messages', messages, { envelope });
     },
   );
 }

--- a/src/mcp/tools/move-message.ts
+++ b/src/mcp/tools/move-message.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { moveMessage } from '../../imap/mutations.js';
+import { moveResultSchema } from '../schemas.js';
+import { jsonResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'move_message' });
@@ -18,11 +20,12 @@ export function registerMoveMessageTool(server: McpServer): void {
         uid: z.coerce.number().int().positive(),
         destination: z.string().min(1).describe('Destination folder path'),
       },
+      outputSchema: moveResultSchema.shape,
     },
     async ({ folder, uid, destination }) => {
       log.info({ folder, uid, destination }, 'moving message');
       const result = await moveMessage(folder, uid, destination);
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      return jsonResult(result, moveResultSchema);
     },
   );
 }

--- a/src/mcp/tools/reply-message.ts
+++ b/src/mcp/tools/reply-message.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { sendReply } from '../../smtp/send.js';
+import { sendResultSchema } from '../schemas.js';
+import { errorResult, jsonResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'reply_message' });
@@ -22,18 +24,16 @@ export function registerReplyMessageTool(server: McpServer): void {
         text: z.string().optional(),
         html: z.string().optional(),
       },
+      outputSchema: sendResultSchema.shape,
     },
     async ({ folder, uid, to, cc, bcc, text, html }) => {
       if (!text && !html) {
-        return {
-          isError: true,
-          content: [{ type: 'text', text: 'Fournir au moins un corps de message (text ou html).' }],
-        };
+        return errorResult('Fournir au moins un corps de message (text ou html).');
       }
 
       log.info({ folder, uid }, 'replying to message');
       const result = await sendReply({ folder, uid, to, cc, bcc, text, html });
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      return jsonResult(result, sendResultSchema);
     },
   );
 }

--- a/src/mcp/tools/save-draft.ts
+++ b/src/mcp/tools/save-draft.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { saveDraft } from '../../imap/drafts.js';
+import { draftResultSchema } from '../schemas.js';
+import { errorResult, jsonResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'save_draft' });
@@ -24,24 +26,19 @@ export function registerSaveDraftTool(server: McpServer): void {
         replyFolder: z.string().optional().describe('Folder of the message being replied to, for threading'),
         replyUid: z.coerce.number().int().positive().optional().describe('UID of the message being replied to'),
       },
+      outputSchema: draftResultSchema.shape,
     },
     async ({ to, cc, bcc, subject, text, html, replyFolder, replyUid }) => {
       if (!text && !html) {
-        return {
-          isError: true,
-          content: [{ type: 'text', text: 'Fournir au moins un corps de message (text ou html).' }],
-        };
+        return errorResult('Fournir au moins un corps de message (text ou html).');
       }
       if ((replyFolder && !replyUid) || (!replyFolder && replyUid)) {
-        return {
-          isError: true,
-          content: [{ type: 'text', text: 'replyFolder et replyUid doivent être fournis ensemble.' }],
-        };
+        return errorResult('replyFolder et replyUid doivent être fournis ensemble.');
       }
 
       log.info({ to, subject, replyFolder, replyUid }, 'saving draft');
       const result = await saveDraft({ to, cc, bcc, subject, text, html, replyFolder, replyUid });
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      return jsonResult(result, draftResultSchema);
     },
   );
 }

--- a/src/mcp/tools/search-messages.ts
+++ b/src/mcp/tools/search-messages.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { searchMessages } from '../../imap/messages.js';
+import { searchMessagesResultSchema } from '../schemas.js';
+import { errorResult, listResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'search_messages' });
@@ -12,7 +14,8 @@ export function registerSearchMessagesTool(server: McpServer): void {
       title: 'Search messages',
       description:
         'Searches messages in a folder using the native IMAP SEARCH command (subject, body, sender, recipient). ' +
-        'At least one of subject/body/from/to is required.',
+        'At least one of subject/body/from/to is required. The text block is a bare array; structuredContent ' +
+        'wraps it under a "messages" key.',
       inputSchema: {
         folder: z.string().min(1).default('INBOX'),
         subject: z.string().optional(),
@@ -20,21 +23,21 @@ export function registerSearchMessagesTool(server: McpServer): void {
         from: z.string().optional(),
         to: z.string().optional(),
         limit: z.coerce.number().int().positive().max(200).default(50),
+        envelope: z
+          .boolean()
+          .default(false)
+          .describe('Wrap the text block under a "messages" key too (structuredContent always is)'),
       },
+      outputSchema: searchMessagesResultSchema.shape,
     },
-    async ({ folder, subject, body, from, to, limit }) => {
+    async ({ folder, subject, body, from, to, limit, envelope }) => {
       if (!subject && !body && !from && !to) {
-        return {
-          isError: true,
-          content: [
-            { type: 'text', text: 'Au moins un critère de recherche est requis (subject, body, from ou to).' },
-          ],
-        };
+        return errorResult('Au moins un critère de recherche est requis (subject, body, from ou to).');
       }
 
       log.info({ folder, subject, from, to }, 'searching messages');
       const messages = await searchMessages(folder, { subject, body, from, to, limit });
-      return { content: [{ type: 'text', text: JSON.stringify(messages, null, 2) }] };
+      return listResult('messages', messages, { envelope });
     },
   );
 }

--- a/src/mcp/tools/send-message.ts
+++ b/src/mcp/tools/send-message.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { sendNewMessage } from '../../smtp/send.js';
+import { sendResultSchema } from '../schemas.js';
+import { errorResult, jsonResult } from '../result.js';
 import { logger } from '../../logger.js';
 
 const log = logger.child({ tool: 'send_message' });
@@ -19,18 +21,16 @@ export function registerSendMessageTool(server: McpServer): void {
         text: z.string().optional(),
         html: z.string().optional(),
       },
+      outputSchema: sendResultSchema.shape,
     },
     async ({ to, cc, bcc, subject, text, html }) => {
       if (!text && !html) {
-        return {
-          isError: true,
-          content: [{ type: 'text', text: 'Fournir au moins un corps de message (text ou html).' }],
-        };
+        return errorResult('Fournir au moins un corps de message (text ou html).');
       }
 
       log.info({ to, subject }, 'sending message');
       const result = await sendNewMessage({ to, cc, bcc, subject, text, html });
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      return jsonResult(result, sendResultSchema);
     },
   );
 }

--- a/src/mcp/tools/wait-for-new-message.ts
+++ b/src/mcp/tools/wait-for-new-message.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { MAX_WAIT_SECONDS, waitForNewMessage } from '../../imap/idle.js';
+import { waitForNewMessageResultSchema } from '../schemas.js';
+import { jsonResult } from '../result.js';
+import { logger } from '../../logger.js';
+
+const log = logger.child({ tool: 'wait_for_new_message' });
+
+export function registerWaitForNewMessageTool(server: McpServer): void {
+  server.registerTool(
+    'wait_for_new_message',
+    {
+      title: 'Wait for new message',
+      description:
+        'Blocks until a new message arrives in the given folder, or until timeoutSec elapses. Uses a dedicated ' +
+        'IMAP connection outside the pool. Returns { timedOut, newMessages }: a reached timeout is not an error. ' +
+        `timeoutSec is capped at ${MAX_WAIT_SECONDS}s.`,
+      inputSchema: {
+        folder: z.string().min(1).default('INBOX'),
+        timeoutSec: z
+          .coerce.number()
+          .int()
+          .positive()
+          .max(MAX_WAIT_SECONDS)
+          .default(60)
+          .describe(`How long to wait, in seconds (max ${MAX_WAIT_SECONDS})`),
+      },
+      outputSchema: waitForNewMessageResultSchema.shape,
+    },
+    async ({ folder, timeoutSec }) => {
+      log.info({ folder, timeoutSec }, 'waiting for new message');
+      const result = await waitForNewMessage(folder, timeoutSec);
+      return jsonResult(result, waitForNewMessageResultSchema);
+    },
+  );
+}

--- a/src/types/html-to-text.d.ts
+++ b/src/types/html-to-text.d.ts
@@ -1,0 +1,10 @@
+/**
+ * `html-to-text` (10.0.1) ne fournit pas de types et `@types/html-to-text`
+ * serait une dépendance nouvelle (interdit par CLAUDE.md). On ne se sert que de
+ * `convert`, dont voici la signature minimale.
+ */
+declare module 'html-to-text' {
+  export function convert(html: string, options?: Record<string, unknown>): string;
+  export function compile(options?: Record<string, unknown>): (html: string) => string;
+  export { convert as htmlToText };
+}

--- a/test/body-truncation.test.ts
+++ b/test/body-truncation.test.ts
@@ -1,0 +1,77 @@
+import './helpers/env.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { prepareMessageBody } from '../src/mcp/message-content.js';
+
+const opts = (over: Partial<{ maxBodyChars: number; includeHtml: boolean }> = {}) => ({
+  maxBodyChars: 20,
+  includeHtml: false,
+  ...over,
+});
+
+describe('prepareMessageBody — troncature', () => {
+  it('ne tronque pas un corps pile à la limite', () => {
+    const text = 'x'.repeat(20);
+    const result = prepareMessageBody({ text, html: false }, opts());
+    assert.equal(result.text, text);
+    assert.equal(result.bodyTruncated, false);
+  });
+
+  it('tronque à la limite exacte et signale la troncature', () => {
+    const result = prepareMessageBody({ text: 'x'.repeat(21), html: false }, opts());
+    assert.equal(result.text?.length, 20);
+    assert.equal(result.bodyTruncated, true);
+  });
+
+  it('ne signale jamais une troncature silencieuse', () => {
+    const result = prepareMessageBody({ text: 'court', html: false }, opts({ maxBodyChars: 5 }));
+    assert.equal(result.bodyTruncated, false);
+  });
+});
+
+describe('prepareMessageBody — repli HTML → texte', () => {
+  it('convertit le HTML en texte quand la partie texte est absente', () => {
+    const result = prepareMessageBody(
+      { text: undefined, html: '<p>Bonjour <b>Alice</b></p>' },
+      opts({ maxBodyChars: 200 }),
+    );
+    assert.equal(result.text, 'Bonjour Alice');
+  });
+
+  it('tronque aussi le texte issu du HTML', () => {
+    const result = prepareMessageBody(
+      { text: undefined, html: `<p>${'a'.repeat(100)}</p>` },
+      opts({ maxBodyChars: 10 }),
+    );
+    assert.equal(result.text?.length, 10);
+    assert.equal(result.bodyTruncated, true);
+  });
+
+  it('préfère la partie texte quand elle existe', () => {
+    const result = prepareMessageBody(
+      { text: 'texte réel', html: '<p>html</p>' },
+      opts({ maxBodyChars: 200 }),
+    );
+    assert.equal(result.text, 'texte réel');
+  });
+
+  it('laisse text indéfini quand il n’y a ni texte ni HTML', () => {
+    const result = prepareMessageBody({ text: undefined, html: false }, opts());
+    assert.equal(result.text, undefined);
+    assert.equal(result.bodyTruncated, false);
+  });
+});
+
+describe('prepareMessageBody — includeHtml', () => {
+  it('omet le HTML par défaut (includeHtml: false)', () => {
+    const result = prepareMessageBody({ text: 'corps', html: '<p>corps</p>' }, opts());
+    assert.equal(result.html, false);
+  });
+
+  it('renvoie le HTML (tronqué) quand includeHtml est true', () => {
+    const html = `<p>${'b'.repeat(100)}</p>`;
+    const result = prepareMessageBody({ text: 'corps', html }, opts({ includeHtml: true, maxBodyChars: 15 }));
+    assert.equal(result.html, html.slice(0, 15));
+    assert.equal(result.bodyTruncated, true);
+  });
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -19,6 +19,41 @@ describe('parseConfig', () => {
     assert.equal(config.PORT, 3000);
     assert.equal(config.LOG_LEVEL, 'info');
     assert.equal(config.IMAP_POOL_SIZE, 2);
+    assert.equal(config.MCP_TRANSPORT, 'http');
+    assert.equal(config.MAX_BODY_CHARS, 20000);
+    assert.equal(config.ENABLE_IDLE_WATCH, false);
+  });
+
+  describe('ENABLE_IDLE_WATCH', () => {
+    it('est off par défaut', () => {
+      assert.equal(parseConfig({ ...validEnv }).ENABLE_IDLE_WATCH, false);
+    });
+
+    for (const value of ['true', '1', 'yes']) {
+      it(`s'active pour ${JSON.stringify(value)}`, () => {
+        assert.equal(parseConfig({ ...validEnv, ENABLE_IDLE_WATCH: value }).ENABLE_IDLE_WATCH, true);
+      });
+    }
+
+    for (const value of ['false', '0', 'no', ' FALSE ']) {
+      it(`reste off pour ${JSON.stringify(value)}`, () => {
+        assert.equal(parseConfig({ ...validEnv, ENABLE_IDLE_WATCH: value }).ENABLE_IDLE_WATCH, false);
+      });
+    }
+  });
+
+  it('accepte les trois valeurs de MCP_TRANSPORT', () => {
+    for (const transport of ['http', 'stdio', 'both'] as const) {
+      assert.equal(parseConfig({ ...validEnv, MCP_TRANSPORT: transport }).MCP_TRANSPORT, transport);
+    }
+  });
+
+  it('rejette un MCP_TRANSPORT inconnu', () => {
+    assert.throws(() => parseConfig({ ...validEnv, MCP_TRANSPORT: 'grpc' }), /MCP_TRANSPORT/);
+  });
+
+  it('convertit MAX_BODY_CHARS en nombre', () => {
+    assert.equal(parseConfig({ ...validEnv, MAX_BODY_CHARS: '5000' }).MAX_BODY_CHARS, 5000);
   });
 
   it('convertit les ports en nombres', () => {

--- a/test/folder-cache.test.ts
+++ b/test/folder-cache.test.ts
@@ -1,0 +1,69 @@
+import './helpers/env.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createFolderCache, filterFolderPaths } from '../src/mcp/folder-cache.js';
+
+describe('filterFolderPaths', () => {
+  const paths = ['INBOX', 'Archive', 'Sent Messages', 'Deleted Messages', 'Notes'];
+
+  it('renvoie tout (dans la limite) pour une saisie vide', () => {
+    assert.deepEqual(filterFolderPaths(paths, ''), paths);
+  });
+
+  it('filtre en sous-chaîne, casse ignorée', () => {
+    assert.deepEqual(filterFolderPaths(paths, 'mess'), ['Sent Messages', 'Deleted Messages']);
+  });
+
+  it('applique la limite', () => {
+    assert.equal(filterFolderPaths(paths, '', 2).length, 2);
+  });
+});
+
+describe('createFolderCache', () => {
+  it('ne recharge pas tant que le TTL n’est pas dépassé', async () => {
+    let calls = 0;
+    let now = 1000;
+    const cache = createFolderCache(
+      async () => {
+        calls += 1;
+        return ['INBOX'];
+      },
+      60_000,
+      () => now,
+    );
+
+    await cache.paths();
+    now = 1000 + 59_999;
+    await cache.paths();
+    assert.equal(calls, 1);
+
+    now = 1000 + 60_001;
+    await cache.paths();
+    assert.equal(calls, 2);
+  });
+
+  it('dédoublonne les chargements concurrents', async () => {
+    let calls = 0;
+    const cache = createFolderCache(async () => {
+      calls += 1;
+      await new Promise((r) => setTimeout(r, 5));
+      return ['INBOX'];
+    });
+
+    await Promise.all([cache.paths(), cache.paths(), cache.paths()]);
+    assert.equal(calls, 1);
+  });
+
+  it('reset force un rechargement', async () => {
+    let calls = 0;
+    const cache = createFolderCache(async () => {
+      calls += 1;
+      return ['INBOX'];
+    });
+
+    await cache.paths();
+    cache.reset();
+    await cache.paths();
+    assert.equal(calls, 2);
+  });
+});

--- a/test/logger-destination.test.ts
+++ b/test/logger-destination.test.ts
@@ -1,0 +1,22 @@
+import './helpers/env.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { logStreamFd } from '../src/logger.js';
+
+/**
+ * C1 — en transport stdio, stdout porte le canal JSON-RPC : les logs doivent
+ * partir sur stderr (fd 2), sinon le serveur devient inutilisable.
+ */
+describe('logStreamFd', () => {
+  it('écrit sur stdout (fd 1) en transport http', () => {
+    assert.equal(logStreamFd('http'), 1);
+  });
+
+  it('bascule sur stderr (fd 2) en transport stdio', () => {
+    assert.equal(logStreamFd('stdio'), 2);
+  });
+
+  it('bascule sur stderr (fd 2) en transport both (stdio actif)', () => {
+    assert.equal(logStreamFd('both'), 2);
+  });
+});

--- a/test/raw-headers.test.ts
+++ b/test/raw-headers.test.ts
@@ -1,0 +1,30 @@
+import './helpers/env.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractRawHeaders } from '../src/mcp/message-content.js';
+
+describe('extractRawHeaders', () => {
+  it('coupe au premier CRLF CRLF et exclut le corps', () => {
+    const source = 'From: a@x\r\nSubject: Salut\r\n\r\nCorps du message\r\navec suite';
+    assert.equal(extractRawHeaders(source), 'From: a@x\r\nSubject: Salut');
+  });
+
+  it('gère les séparateurs LF LF (messages non normalisés)', () => {
+    const source = 'From: a@x\nSubject: Salut\n\nCorps';
+    assert.equal(extractRawHeaders(source), 'From: a@x\nSubject: Salut');
+  });
+
+  it('accepte un Buffer', () => {
+    const source = Buffer.from('List-Unsubscribe: <https://x/u>\r\n\r\nbody', 'utf8');
+    assert.equal(extractRawHeaders(source), 'List-Unsubscribe: <https://x/u>');
+  });
+
+  it('renvoie tout le contenu quand il n’y a pas de corps', () => {
+    assert.equal(extractRawHeaders('From: a@x\r\nSubject: rien'), 'From: a@x\r\nSubject: rien');
+  });
+
+  it('préfère le séparateur CRLF CRLF quand les deux styles cohabitent', () => {
+    const source = 'A: 1\r\nB: 2\r\n\r\nligne\n\nautre';
+    assert.equal(extractRawHeaders(source), 'A: 1\r\nB: 2');
+  });
+});

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -1,0 +1,83 @@
+import './helpers/env.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { z } from 'zod';
+import { errorResult, jsonResult, listResult } from '../src/mcp/result.js';
+import { listMessagesResultSchema, moveResultSchema } from '../src/mcp/schemas.js';
+
+describe('jsonResult', () => {
+  const data = { uid: 42, from: 'INBOX', to: 'Archive', newUid: 7 };
+
+  it('sérialise toujours les données dans un bloc texte', () => {
+    const result = jsonResult(data);
+    assert.equal(result.content.length, 1);
+    assert.equal(result.content[0]?.type, 'text');
+    assert.deepEqual(JSON.parse((result.content[0] as { text: string }).text), data);
+  });
+
+  it("n'attache pas de structuredContent sans schéma", () => {
+    assert.equal(jsonResult(data).structuredContent, undefined);
+  });
+
+  it('attache structuredContent quand un schéma est fourni', () => {
+    const result = jsonResult(data, moveResultSchema);
+    assert.deepEqual(result.structuredContent, data);
+  });
+
+  it('produit un structuredContent qui valide contre son outputSchema', () => {
+    const result = jsonResult(data, moveResultSchema);
+    assert.doesNotThrow(() => moveResultSchema.parse(result.structuredContent));
+  });
+
+  it('conserve le bloc texte ET le structuré en parallèle', () => {
+    const result = jsonResult(data, moveResultSchema);
+    assert.ok(result.content[0]);
+    assert.ok(result.structuredContent);
+  });
+
+  it('laisse le SDK détecter un structuredContent non conforme au schéma', () => {
+    const strict = z.object({ a: z.number() });
+    const result = jsonResult({ a: 'pas un nombre' }, strict);
+    assert.throws(() => strict.parse(result.structuredContent));
+  });
+});
+
+describe('listResult', () => {
+  const items = [{ uid: 1 }, { uid: 2 }];
+  const textOf = (r: ReturnType<typeof listResult>) => JSON.parse((r.content[0] as { text: string }).text);
+
+  it('bloc texte = tableau nu par défaut (contrat historique)', () => {
+    assert.deepEqual(textOf(listResult('messages', items)), items);
+  });
+
+  it('structuredContent = toujours enveloppé (objet exigé par le protocole)', () => {
+    assert.deepEqual(listResult('messages', items).structuredContent, { messages: items });
+  });
+
+  it('envelope: true enveloppe aussi le bloc texte', () => {
+    assert.deepEqual(textOf(listResult('messages', items, { envelope: true })), { messages: items });
+  });
+
+  it('un nextCursor force l’enveloppe du bloc texte, même sans envelope', () => {
+    const result = listResult('messages', items, { nextCursor: 'abc' });
+    assert.deepEqual(textOf(result), { messages: items, nextCursor: 'abc' });
+    assert.deepEqual(result.structuredContent, { messages: items, nextCursor: 'abc' });
+  });
+
+  it('la forme enveloppée valide contre son outputSchema', () => {
+    const result = listResult('messages', [], { envelope: true });
+    assert.doesNotThrow(() => listMessagesResultSchema.parse(result.structuredContent));
+  });
+});
+
+describe('errorResult', () => {
+  it('pose isError et le message utilisateur en texte', () => {
+    const result = errorResult('Dossier introuvable.');
+    assert.equal(result.isError, true);
+    assert.equal((result.content[0] as { text: string }).text, 'Dossier introuvable.');
+  });
+
+  it("n'attache jamais de structuredContent", () => {
+    assert.equal(errorResult('bang').structuredContent, undefined);
+  });
+});


### PR DESCRIPTION
Turn the server from a pile of JSON-string tools into a proper MCP citizen.

Transport:
- MCP_TRANSPORT=http|stdio|both; the HTTP mount is conditional and shutdown
  closes only what was started
- the logger switches to stderr (pino.destination(2)) whenever stdio is
  active, so it never corrupts the JSON-RPC channel on stdout

get_message response size:
- maxBodyChars (default MAX_BODY_CHARS=20000) plus an explicit bodyTruncated
  flag; truncation is never silent
- includeHtml, default false: the raw HTML body no longer floods the context
- html -> text fallback when the message has no text part, via html-to-text
  (promoted to a direct dependency, same pinned 10.0.1 as the existing override)
- includeRawHeaders: RFC 5322 header block only, backed by getMessageSource

Structured output:
- every tool declares an outputSchema and returns structuredContent alongside
  the text block; schemas are derived from the existing IMAP/SMTP types
- list tools keep their bare-array text block by default; structuredContent
  always uses the wrapped form ({ folders }, { messages }), and a new envelope
  input wraps the text block too

Resources, prompts, completions:
- resources mail://folders and mail://folder/{+path}/message/{uid}
- prompts triage-inbox, summarize-thread, draft-reply (French)
- folder-name completion for the folder argument, cached 60s

wait_for_new_message: a minimal IDLE watch on a dedicated out-of-pool
connection with a bounded timeout, registered only when ENABLE_IDLE_WATCH is
set (default off) since it has no reconnection.

Tests: +47 (154 total), no network. Docs: tools.md, deployment.md,
configuration.md.

Closes #16
Closes #17
Closes #18
Closes #19

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
