### PR TITLE
Prépare la v0.1.0 : rename, pipeline de release, finitions déploiement

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,13 @@ dist
 !.env.example
 *.log
 .git
+.github
 .DS_Store
+
+# Non nécessaires à la construction de l'image (dépendances de dev seules).
+test
+docs
+*.md
+!README.md
+.prettierrc.json
+eslint.config.js

--- a/.env.example
+++ b/.env.example
@@ -100,13 +100,5 @@ TUNNEL_TOKEN=
 LOG_LEVEL=info
 
 # --- Divers -------------------------------------------------------------------
-# Toutes optionnelles : les valeurs ci-dessous sont les defauts.
-
 # Taille maximale d'une piece jointe, en octets (defaut : 5 Mio).
 ATTACHMENT_MAX_BYTES=5242880
-
-# Longueur maximale d'un corps de message (texte ou HTML) accepte par les outils.
-MAX_BODY_CHARS=20000
-
-# Transport expose par le serveur MCP : http | stdio | both.
-MCP_TRANSPORT=http

--- a/.env.example
+++ b/.env.example
@@ -89,7 +89,11 @@ UNRESTRICTED=false
 # docs/configuration.md.
 ENABLE_IDLE_WATCH=false
 
-# --- Cloudflare Tunnel (docker-compose) -----------------------------------------
+# --- Deploiement (docker-compose) ---------------------------------------------
+# Tag de l'image GHCR tiree par docker-compose.yml. Une version precise
+# ("0.1.0") pour epingler, "latest" pour suivre le dernier tag publie.
+ICLOUD_MAIL_MCP_VERSION=latest
+
 # Token du tunnel, genere dans le dashboard Cloudflare Zero Trust
 # (Networks -> Tunnels -> Créer un tunnel -> Docker). Utilise uniquement par
 # le service "cloudflared" du docker-compose.yml, pas par l'app elle-même.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      # Un seul PR par vague de mises à jour mineures/patch.
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,31 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  docker:
+    name: Build de l'image Docker
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-buildx-action@v3
+
+      # Construit exactement comme la release (linux/amd64), sans pousser :
+      # un Dockerfile cassé fait échouer le CI au lieu de passer inaperçu.
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: icloud-mail-mcp:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # L'entrypoint réel démarrerait un serveur en attente : on se contente de
+      # vérifier que l'artefact compilé est bien là et se charge sans erreur.
+      - name: Smoke test de l'image
+        run: |
+          docker run --rm icloud-mail-mcp:ci \
+            node --input-type=module -e "import('/app/dist/version.js').then(m => process.exit(m.serverVersion ? 0 : 1))"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+# Une release = un tag `vX.Y.Z`. Le tag doit correspondre au champ `version`
+# de package.json (le job le vérifie). Procédure complète : CHANGELOG.md.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write # créer la GitHub Release
+  packages: write # pousser l'image sur GHCR
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Vérifier que le tag correspond à package.json
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(node -p "require('./package.json').version")"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME != package.json version $pkg"
+            exit 1
+          fi
+
+      # Le CI complet (typecheck, lint, tests, build, image) tourne sur main
+      # avant le tag ; on rejoue tests + build ici pour ne rien publier d'un
+      # arbre qui ne compile pas.
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm test
+      - run: npm run build
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Connexion à GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Métadonnées de l'image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          body: |
+            Image : `${{ env.IMAGE }}:${{ github.ref_name }}`
+
+            Déploiement : bumper `ICLOUD_MAIL_MCP_VERSION` dans `.env`, puis
+            `docker compose pull && docker compose up -d`. Voir `docs/deployment.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/),
+versionnage [SemVer](https://semver.org/lang/fr/).
+
+## Procédure de release
+
+1. Mettre à jour ce fichier : renommer `[Non publié]` en `[X.Y.Z] - AAAA-MM-JJ`.
+2. Bumper `version` dans `package.json` (source unique, lue par `src/version.ts`
+   et exposée sur `/health` + l'outil `whoami`).
+3. Commit sur `main` via PR.
+4. `git tag -a vX.Y.Z -m "vX.Y.Z"` puis `git push origin vX.Y.Z`.
+5. Le workflow `release.yml` vérifie que le tag == `package.json`, rejoue
+   tests + build, pousse `ghcr.io/leolesimple/icloud-mail-mcp:{X.Y.Z, X.Y, latest}`
+   (linux/amd64) et crée la GitHub Release.
+
+---
+
+## [Non publié]
+
+_Rien pour l'instant._
+
+## [0.1.0] - 2026-08-31
+
+Première version publiée. Serveur MCP exposant un compte iCloud Mail
+(IMAP/SMTP) sous forme d'outils pour Claude.
+
+### Ajouté
+
+- **17 outils MCP** : `list_folders`, `list_messages`, `search_messages`,
+  `get_message`, `get_attachment`, `get_thread`, `send_message`,
+  `reply_message`, `forward_message`, `save_draft`, `update_draft`,
+  `send_draft`, `move_message`, `delete_message`, `flag_message`,
+  `manage_folder`, `whoami`. Un 18ᵉ, `wait_for_new_message`, derrière
+  `ENABLE_IDLE_WATCH` (OFF par défaut, pas de reconnexion — voir #20).
+- Opérations de masse : `uid` unique ou jusqu'à 200 `uids` par commande IMAP.
+- **Garde-fous d'envoi gradués** : `ENABLE_SENDING`, `DRAFTS_ONLY`, allowlist
+  de destinataires, quota journalier, `UNRESTRICTED`. Appliqués au niveau du
+  transport SMTP, verrouillés par des tests.
+- Deux transports MCP : HTTP streamable et stdio (`MCP_TRANSPORT`).
+- Resources (`mail://folders`, `mail://folder/{path}/message/{uid}`) et prompts
+  MCP.
+- HTTP : bearer token, rate limit à fenêtre glissante, TTL des sessions,
+  `/health` non authentifié renvoyant statut + version.
+- `npm run auth` : vérifie IMAP et SMTP pour de vrai avant d'écrire `.env`.
+- Déploiement de référence : image Docker (`node` non-root, multi-étages,
+  HEALTHCHECK) + Cloudflare Tunnel, aucun port publié sur l'hôte.
+- Logs structurés pino, sans secret ni contenu de mail. 340 tests hors réseau.
+
+### Infrastructure de release (préparation 0.1.0)
+
+- Renommage `mail-mcp` → `icloud-mail-mcp` (l'id du serveur MCP reste
+  `icloud-mail`).
+- Déploiement par image publiée : `docker-compose.yml` tire
+  `ghcr.io/leolesimple/icloud-mail-mcp` au tag `ICLOUD_MAIL_MCP_VERSION` ;
+  `docker-compose.dev.yml` pour le build local.
+- CI : job de build de l'image Docker. `release.yml` : tag `v*` → image GHCR
+  (linux/amd64) + GitHub Release.
+- IP cliente résolue via `CF-Connecting-IP` derrière le tunnel (le rate limit
+  par IP ne s'effondre plus en un seul seau).
+- Dependabot sur npm et GitHub Actions.
+
+[Non publié]: https://github.com/leolesimple/icloud-mail-mcp/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/leolesimple/icloud-mail-mcp/releases/tag/v0.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,26 @@
-FROM node:24-alpine AS development-dependencies-env
+# Image de base commune à toutes les étapes. Par défaut on suit `node:24-alpine`
+# (patchs de sécurité repris à chaque rebuild) ; le workflow de release peut
+# passer --build-arg NODE_IMAGE=node:24-alpine@sha256:... pour figer un digest.
+ARG NODE_IMAGE=node:24-alpine
+
+FROM ${NODE_IMAGE} AS development-dependencies-env
 COPY . /app
 WORKDIR /app
 RUN npm ci
 
-FROM node:24-alpine AS production-dependencies-env
+FROM ${NODE_IMAGE} AS production-dependencies-env
 COPY ./package.json package-lock.json /app/
 WORKDIR /app
 RUN npm ci --omit=dev
 
-FROM node:24-alpine AS build-env
+FROM ${NODE_IMAGE} AS build-env
 COPY . /app/
 COPY --from=development-dependencies-env /app/node_modules /app/node_modules
 WORKDIR /app
 RUN npm run build
 
-FROM node:24-alpine
+FROM ${NODE_IMAGE}
+ENV NODE_ENV=production
 COPY ./package.json package-lock.json /app/
 COPY --from=production-dependencies-env /app/node_modules /app/node_modules
 COPY --from=build-env /app/dist /app/dist

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-mail-mcp — Proprietary Use-Only License
+icloud-mail-mcp — Proprietary Use-Only License
 Copyright (c) 2026 Léo Lesimple. All rights reserved.
 
 This software is NOT open source. It is published publicly so that it can be

--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ Ce serveur peut lire, déplacer, supprimer et envoyer des mails. Les points à n
   clic sur appleid.apple.com si le serveur est compromis.
 - **Commencez avec `ENABLE_SENDING=false`.** Vous rallumerez l'envoi quand vous aurez vu comment
   Claude se comporte sur votre boîte.
-- **Le healthcheck `/health` n'est pas authentifié** — il ne révèle que `{"status":"ok"}`.
+- **Le healthcheck `/health` n'est pas authentifié** — il ne révèle que le statut et la version
+  du serveur (`{"status":"ok","version":"…"}`), aucune configuration ni secret.
 
 Détail complet dans [`docs/security.md`](docs/security.md).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# mail-mcp
+# icloud-mail-mcp
 
-[![CI](https://github.com/leolesimple/mail-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/leolesimple/mail-mcp/actions/workflows/ci.yml)
+[![CI](https://github.com/leolesimple/icloud-mail-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/leolesimple/icloud-mail-mcp/actions/workflows/ci.yml)
 
 Serveur [MCP](https://modelcontextprotocol.io) qui expose un compte **iCloud Mail** (IMAP/SMTP) sous
 forme d'outils utilisables par Claude : lire, chercher, trier, répondre et archiver des mails depuis
@@ -11,7 +11,7 @@ transite par un service tiers : Claude parle directement à votre instance, qui 
 iCloud.
 
 ```
-Claude  ──HTTPS+Bearer──▶  Cloudflare Tunnel  ──▶  mail-mcp  ──IMAP/SMTP+TLS──▶  iCloud
+Claude  ──HTTPS+Bearer──▶  Cloudflare Tunnel  ──▶  icloud-mail-mcp  ──IMAP/SMTP+TLS──▶  iCloud
 ```
 
 > **Licence — à lire avant de cloner.** Ce projet **n'est pas open source**. Vous pouvez le
@@ -94,15 +94,15 @@ Concrètement, une fois branché, on peut demander à Claude :
   en IMAP/SMTP :
   1. [appleid.apple.com](https://appleid.apple.com/) → se connecter
   2. **Connexion et sécurité** → **Mots de passe pour applications** → **Générer un mot de passe**
-  3. Nommer (« mail-mcp ») et copier le mot de passe au format `xxxx-xxxx-xxxx-xxxx`
+  3. Nommer (« icloud-mail-mcp ») et copier le mot de passe au format `xxxx-xxxx-xxxx-xxxx`
 
 ---
 
 ## Démarrage rapide
 
 ```bash
-git clone https://github.com/leolesimple/mail-mcp.git
-cd mail-mcp
+git clone https://github.com/leolesimple/icloud-mail-mcp.git
+cd icloud-mail-mcp
 npm install
 npm run auth
 ```
@@ -144,12 +144,12 @@ Pour le déploiement Docker + Cloudflare Tunnel, voir [`docs/deployment.md`](doc
 **Claude Code** :
 
 ```bash
-claude mcp add --transport http mail-mcp https://mail-mcp.exemple.com/mcp \
+claude mcp add --transport http icloud-mail-mcp https://icloud-mail-mcp.exemple.com/mcp \
   --header "Authorization: Bearer <votre token>"
 ```
 
 **Claude Desktop / claude.ai** : *Paramètres → Connecteurs → Ajouter un connecteur personnalisé*,
-en donnant l'URL `https://mail-mcp.exemple.com/mcp`.
+en donnant l'URL `https://icloud-mail-mcp.exemple.com/mcp`.
 
 Détails et dépannage dans [`docs/deployment.md`](docs/deployment.md#brancher-un-client-mcp).
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Concrètement, une fois branché, on peut demander à Claude :
   `.env`, plutôt que de découvrir la faute de frappe au premier appel d'outil.
 - **Deux transports** — HTTP streamable, ou stdio pour un branchement local (`MCP_TRANSPORT`).
 - **Logs structurés** (pino) sans mot de passe ni contenu de mail.
-- **333 tests** qui ne touchent ni le réseau ni une vraie boîte mail.
+- **340 tests** qui ne touchent ni le réseau ni une vraie boîte mail.
 
 ---
 
@@ -195,6 +195,7 @@ Détail complet dans [`docs/security.md`](docs/security.md).
 | [`docs/architecture.md`](docs/architecture.md) | Découpage en couches, pool IMAP, gestion des erreurs et des sessions |
 | [`docs/security.md`](docs/security.md) | Modèle de menace et bonnes pratiques |
 | [`docs/development.md`](docs/development.md) | Structure du code, tests, conventions |
+| [`CHANGELOG.md`](CHANGELOG.md) | Historique des versions et procédure de release |
 
 ---
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,14 @@
+# Surcharge pour le développement local : construit l'image depuis les sources
+# au lieu de tirer celle de GHCR, et publie le port sur l'hôte pour viser
+# http://localhost:3000 sans tunnel.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+#
+# À ne pas utiliser sur une machine exposée : le port devient joignable
+# directement, hors du tunnel.
+services:
+  icloud-mail-mcp:
+    build: .
+    image: icloud-mail-mcp:dev
+    ports:
+      - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
-  mail-mcp:
+  icloud-mail-mcp:
     build: .
-    container_name: mail-mcp
+    container_name: icloud-mail-mcp
     # Pour tester en local : decommente la ligne ci-dessous puis accede a http://localhost:3000
     # ports:
     #   - "3000:3000"
@@ -9,16 +9,16 @@ services:
       - .env
     restart: unless-stopped
     networks:
-      - mail-mcp-net
+      - icloud-mail-mcp-net
 
   cloudflared:
     image: cloudflare/cloudflared:2025.2
-    container_name: mail-mcp-cloudflared
-    command: tunnel --no-autoupdate run --token ${TUNNEL_TOKEN} --url http://mail-mcp:3000
+    container_name: icloud-mail-mcp-cloudflared
+    command: tunnel --no-autoupdate run --token ${TUNNEL_TOKEN} --url http://icloud-mail-mcp:3000
     restart: unless-stopped
     networks:
-      - mail-mcp-net
+      - icloud-mail-mcp-net
 
 networks:
-  mail-mcp-net:
+  icloud-mail-mcp-net:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 services:
   icloud-mail-mcp:
-    build: .
+    # Image publiée sur GHCR à chaque tag `v*` (voir .github/workflows/release.yml).
+    # Fixer ICLOUD_MAIL_MCP_VERSION dans .env pour épingler une version ;
+    # `latest` suit le dernier tag. Le build local passe par docker-compose.dev.yml.
+    image: ghcr.io/leolesimple/icloud-mail-mcp:${ICLOUD_MAIL_MCP_VERSION:-latest}
     container_name: icloud-mail-mcp
-    # Pour tester en local : decommente la ligne ci-dessous puis accede a http://localhost:3000
-    # ports:
-    #   - "3000:3000"
     env_file:
       - .env
     restart: unless-stopped
@@ -16,6 +16,11 @@ services:
     container_name: icloud-mail-mcp-cloudflared
     command: tunnel --no-autoupdate run --token ${TUNNEL_TOKEN} --url http://icloud-mail-mcp:3000
     restart: unless-stopped
+    # Le HEALTHCHECK est porté par l'image : on n'ouvre le tunnel qu'une fois le
+    # serveur prêt à répondre sur /health.
+    depends_on:
+      icloud-mail-mcp:
+        condition: service_healthy
     networks:
       - icloud-mail-mcp-net
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,7 @@ Un serveur Express avec trois routes :
 | `POST /mcp` | bearer | Requêtes JSON-RPC, dont `initialize` qui ouvre une session |
 | `GET /mcp` | bearer | Flux SSE de notifications serveur → client |
 | `DELETE /mcp` | bearer | Fermeture explicite d'une session |
-| `GET /health` | **aucune** | Healthcheck Docker, renvoie `{"status":"ok"}` |
+| `GET /health` | **aucune** | Healthcheck Docker, renvoie `{"status":"ok","version":"<x.y.z>"}` |
 
 ### Authentification
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -184,7 +184,7 @@ pool et attend l'événement `exists` d'iCloud. Cette version n'a **pas de recon
 connexion iCloud saute pendant l'attente (coupure réseau, throttling, timeout serveur), l'outil ne
 le détecte pas et se contente d'expirer avec `timedOut: true` — un nouveau message arrivé
 entre-temps est manqué **sans le moindre signal**. Tant que la version avec reconnexion n'est pas
-faite ([#20](https://github.com/leolesimple/mail-mcp/issues/20)), l'outil n'est exposé que si vous
+faite ([#20](https://github.com/leolesimple/icloud-mail-mcp/issues/20)), l'outil n'est exposé que si vous
 l'activez explicitement, en connaissance de cause.
 
 Reconnus comme « activé » : toute valeur autre que `false`, `0`, `no` (casse et espaces ignorés).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -70,11 +70,12 @@ Puis, depuis n'importe où :
 
 ```bash
 curl https://icloud-mail-mcp.exemple.com/health
-# {"status":"ok"}
+# {"status":"ok","version":"0.1.0"}
 ```
 
-Le `/health` répond sans token — c'est voulu, le healthcheck Docker en a besoin. Il ne révèle rien
-d'autre que le fait que le service tourne.
+Le `/health` répond sans token — c'est voulu, le healthcheck Docker en a besoin. Il ne révèle que le
+statut et la version du serveur (utile pour vérifier quelle image tourne après un déploiement),
+jamais de configuration ni de secret.
 
 ### Ce que fait l'image
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,7 +5,7 @@ l'hôte**, et un Cloudflare Tunnel qui expose le endpoint en HTTPS sans ouvrir d
 routeur.
 
 ```
-Internet ──HTTPS──▶ Cloudflare ──tunnel sortant──▶ cloudflared ──http://mail-mcp:3000──▶ mail-mcp
+Internet ──HTTPS──▶ Cloudflare ──tunnel sortant──▶ cloudflared ──http://icloud-mail-mcp:3000──▶ icloud-mail-mcp
                                                         └──── réseau bridge privé ────┘
 ```
 
@@ -23,20 +23,20 @@ Dans le dashboard [Cloudflare Zero Trust](https://one.dash.cloudflare.com/) :
 2. Type **Cloudflared**, nommer le tunnel
 3. Choisir l'environnement **Docker** et copier le token affiché (une longue chaîne)
 4. Onglet **Public Hostname** → **Add a public hostname** :
-   - *Subdomain* : `mail-mcp` (par exemple)
+   - *Subdomain* : `icloud-mail-mcp` (par exemple)
    - *Domain* : votre domaine
-   - *Service* : **HTTP** → `mail-mcp:3000`
+   - *Service* : **HTTP** → `icloud-mail-mcp:3000`
 
 Le service pointe vers le **nom du conteneur**, pas vers `localhost` : les deux conteneurs partagent
-le réseau `mail-mcp-net` du compose.
+le réseau `icloud-mail-mcp-net` du compose.
 
 ---
 
 ## 2. Préparer l'hôte
 
 ```bash
-git clone https://github.com/leolesimple/mail-mcp.git
-cd mail-mcp
+git clone https://github.com/leolesimple/icloud-mail-mcp.git
+cd icloud-mail-mcp
 cp .env.example .env
 ```
 
@@ -62,14 +62,14 @@ Vérifier :
 
 ```bash
 docker compose ps                    # les deux conteneurs doivent être "healthy"/"running"
-docker compose logs -f mail-mcp      # "mail-mcp http server listening"
+docker compose logs -f icloud-mail-mcp      # "icloud-mail-mcp http server listening"
 docker compose logs -f cloudflared   # "Registered tunnel connection"
 ```
 
 Puis, depuis n'importe où :
 
 ```bash
-curl https://mail-mcp.exemple.com/health
+curl https://icloud-mail-mcp.exemple.com/health
 # {"status":"ok"}
 ```
 
@@ -88,7 +88,7 @@ via `env_file`. L'image ne contient donc aucun secret et peut être reconstruite
 
 ### Tester en local sans tunnel
 
-Décommenter la section `ports:` du service `mail-mcp` dans `docker-compose.yml`, puis viser
+Décommenter la section `ports:` du service `icloud-mail-mcp` dans `docker-compose.yml`, puis viser
 `http://localhost:3000/mcp`. **À ne pas laisser en place sur une machine exposée.**
 
 ---
@@ -118,7 +118,7 @@ fonctionne à l'identique dans les trois modes.
 ### Claude Code — HTTP (déploiement distant)
 
 ```bash
-claude mcp add --transport http mail-mcp https://mail-mcp.exemple.com/mcp \
+claude mcp add --transport http icloud-mail-mcp https://icloud-mail-mcp.exemple.com/mcp \
   --header "Authorization: Bearer <votre token>"
 ```
 
@@ -130,11 +130,11 @@ outils.
 Pour lancer le serveur en local, sans HTTP ni tunnel :
 
 ```bash
-claude mcp add mail-mcp -- \
+claude mcp add icloud-mail-mcp -- \
   env MCP_TRANSPORT=stdio \
       ICLOUD_EMAIL=vous@icloud.com ICLOUD_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx \
       MCP_BEARER_TOKEN=$(openssl rand -hex 16) \
-  node /chemin/vers/mail-mcp/dist/index.js
+  node /chemin/vers/icloud-mail-mcp/dist/index.js
 ```
 
 (ou `npx tsx src/index.ts` en développement). Le client démarre le processus lui-même ; `PORT`
@@ -145,14 +145,14 @@ convient.
 ### Claude Desktop / claude.ai
 
 *Paramètres → Connecteurs → Ajouter un connecteur personnalisé*, avec l'URL
-`https://mail-mcp.exemple.com/mcp`.
+`https://icloud-mail-mcp.exemple.com/mcp`.
 
 ### MCP Inspector (débogage)
 
 ```bash
 npx @modelcontextprotocol/inspector
 # Transport : Streamable HTTP
-# URL       : https://mail-mcp.exemple.com/mcp
+# URL       : https://icloud-mail-mcp.exemple.com/mcp
 # Header    : Authorization: Bearer <votre token>
 ```
 
@@ -180,7 +180,7 @@ au prochain appel.
 | `Configuration invalide` au démarrage | Une variable manque ou est mal formée — le message liste précisément lesquelles. |
 | `Authentification iCloud IMAP refusée` | Mot de passe principal utilisé à la place d'un mot de passe d'application, ou mot de passe révoqué. |
 | `401` sur `/mcp`, `/health` OK | Token absent ou différent de `MCP_BEARER_TOKEN`. Vérifier le préfixe `Bearer ` et l'absence d'espace parasite. |
-| `502` Cloudflare | Le conteneur `mail-mcp` est arrêté, ou le hostname public pointe vers le mauvais port/nom de service. |
+| `502` Cloudflare | Le conteneur `icloud-mail-mcp` est arrêté, ou le hostname public pointe vers le mauvais port/nom de service. |
 | Erreurs IMAP intermittentes | Throttling iCloud. Baisser `IMAP_POOL_SIZE`, ou espacer les appels. |
 | Le tunnel ne se connecte pas | `TUNNEL_TOKEN` invalide ou tunnel supprimé côté Cloudflare. |
 | En stdio, le client MCP n'obtient jamais de réponse | Quelque chose écrit sur stdout du processus (wrapper qui fait `2>&1`, `console.log` ajouté, autre lib bavarde). stdout est réservé au JSON-RPC. |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,6 +34,10 @@ le réseau `icloud-mail-mcp-net` du compose.
 
 ## 2. Préparer l'hôte
 
+Le déploiement ne compile rien sur l'hôte : `docker-compose.yml` tire l'image publiée sur
+`ghcr.io/leolesimple/icloud-mail-mcp` à chaque tag `v*`. Seuls le `docker-compose.yml` et le `.env`
+sont nécessaires — cloner le dépôt reste le plus simple pour les récupérer.
+
 ```bash
 git clone https://github.com/leolesimple/icloud-mail-mcp.git
 cd icloud-mail-mcp
@@ -47,7 +51,8 @@ ICLOUD_EMAIL=vous@icloud.com
 ICLOUD_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx
 MCP_BEARER_TOKEN=<openssl rand -hex 32>
 TUNNEL_TOKEN=<le token copié à l'étape 1>
-ENABLE_SENDING=false      # à laisser à false pour la première mise en service
+ICLOUD_MAIL_MCP_VERSION=0.1.0   # version à déployer ("latest" pour suivre le dernier tag)
+ENABLE_SENDING=false            # à laisser à false pour la première mise en service
 ```
 
 ---
@@ -55,15 +60,19 @@ ENABLE_SENDING=false      # à laisser à false pour la première mise en servic
 ## 3. Lancer
 
 ```bash
-docker compose up -d --build
+docker compose up -d
 ```
+
+`docker compose` tire l'image GHCR (le paquet est public, aucune authentification requise) puis
+démarre les deux conteneurs. `cloudflared` attend que `icloud-mail-mcp` soit *healthy* avant
+d'ouvrir le tunnel.
 
 Vérifier :
 
 ```bash
-docker compose ps                    # les deux conteneurs doivent être "healthy"/"running"
-docker compose logs -f icloud-mail-mcp      # "icloud-mail-mcp http server listening"
-docker compose logs -f cloudflared   # "Registered tunnel connection"
+docker compose ps                          # les deux conteneurs "healthy"/"running"
+docker compose logs -f icloud-mail-mcp     # "icloud-mail-mcp http server listening"
+docker compose logs -f cloudflared         # "Registered tunnel connection"
 ```
 
 Puis, depuis n'importe où :
@@ -81,16 +90,25 @@ jamais de configuration ni de secret.
 
 Le [`Dockerfile`](../Dockerfile) est multi-étages : dépendances de développement pour compiler le
 TypeScript, dépendances de production seules dans l'image finale. Celle-ci ne contient ni le code
-source, ni les outils de build, tourne en utilisateur `node` non-root, et embarque un `HEALTHCHECK`
-qui interroge `/health`.
+source, ni les outils de build, tourne en utilisateur `node` non-root, pose `NODE_ENV=production`,
+et embarque un `HEALTHCHECK` qui interroge `/health`. L'image est construite pour `linux/amd64` par
+[`.github/workflows/release.yml`](../.github/workflows/release.yml) et poussée sur GHCR taguée
+`X.Y.Z` **et** `latest`.
 
 `.env` **n'est pas copié dans l'image** (il est dans `.dockerignore`) : il est injecté à l'exécution
-via `env_file`. L'image ne contient donc aucun secret et peut être reconstruite sans risque.
+via `env_file`. L'image ne contient donc aucun secret.
 
-### Tester en local sans tunnel
+### Tester en local (build depuis les sources)
 
-Décommenter la section `ports:` du service `icloud-mail-mcp` dans `docker-compose.yml`, puis viser
-`http://localhost:3000/mcp`. **À ne pas laisser en place sur une machine exposée.**
+`docker-compose.dev.yml` surcharge le service : build local au lieu du pull GHCR, et port publié
+sur l'hôte.
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+curl http://localhost:3000/health
+```
+
+**À ne pas utiliser sur une machine exposée** : le port devient joignable hors du tunnel.
 
 ---
 
@@ -164,10 +182,16 @@ rapide de distinguer un problème de serveur d'un problème de modèle.
 
 ## Mise à jour
 
+Bumper `ICLOUD_MAIL_MCP_VERSION` dans `.env` vers le nouveau tag, puis :
+
 ```bash
-git pull
-docker compose up -d --build
+docker compose pull
+docker compose up -d
 ```
+
+Rien à compiler sur l'hôte, rien à `git pull` sauf si `docker-compose.yml` lui-même a changé.
+Revenir en arrière = remettre l'ancienne valeur et rejouer les deux commandes. Vérifier la version
+réellement en ligne : `curl https://icloud-mail-mcp.exemple.com/health`.
 
 Les sessions MCP en cours sont perdues au redémarrage ; les clients en rouvrent une automatiquement
 au prochain appel.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -63,9 +63,13 @@ ENABLE_SENDING=false            # à laisser à false pour la première mise en 
 docker compose up -d
 ```
 
-`docker compose` tire l'image GHCR (le paquet est public, aucune authentification requise) puis
-démarre les deux conteneurs. `cloudflared` attend que `icloud-mail-mcp` soit *healthy* avant
-d'ouvrir le tunnel.
+`docker compose` tire l'image GHCR puis démarre les deux conteneurs. `cloudflared` attend que
+`icloud-mail-mcp` soit *healthy* avant d'ouvrir le tunnel.
+
+> Le paquet GHCR est privé par défaut à la première publication. Une fois : le rendre public
+> (*Packages → icloud-mail-mcp → Package settings → Change visibility*), ou, pour le garder privé,
+> `echo $TOKEN | docker login ghcr.io -u leolesimple --password-stdin` sur l'hôte avec un PAT
+> `read:packages`.
 
 Vérifier :
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -84,7 +84,7 @@ qui mérite un test appartient aux couches basses.
 npm test
 ```
 
-**333 tests**, exécutés par le runner intégré de Node (`node:test`) via tsx. Aucune dépendance de
+**340 tests**, exécutés par le runner intégré de Node (`node:test`) via tsx. Aucune dépendance de
 test supplémentaire, aucun framework à maintenir.
 
 | Fichier | Ce qui est couvert |
@@ -96,7 +96,8 @@ test supplémentaire, aucun framework à maintenir.
 | `messages.test.ts` | Projections d'enveloppe, flags, dates ISO, champs manquants |
 | `pool.test.ts` | Réutilisation, taille max, file d'attente, purge des connexions mortes, retry, fermeture |
 | `auth.test.ts` | Bearer valide, absent, tronqué, rallongé, mauvais schéma |
-| `http.test.ts` | Serveur réel : `/health`, `401`, cycle de session MCP complet |
+| `http.test.ts` | Serveur réel : `/health` + version, `401`, rate limit par `CF-Connecting-IP`, cycle de session MCP complet |
+| `client-ip.test.ts` | Résolution de l'IP appelante (`CF-Connecting-IP`, `req.ip`, socket, `unknown`) |
 | `sending-guard.test.ts` | `ENABLE_SENDING=false` bloque l'envoi avant toute connexion SMTP |
 
 ### Deux invariants tenus par la suite
@@ -128,11 +129,16 @@ Les imports pointent vers les fichiers sources en `.js` (résolution NodeNext), 
 ## Intégration continue
 
 [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) rejoue `typecheck`, `lint`, `test` et
-`build` sur Node 24, à chaque push sur `main` et sur chaque pull request.
+`build` sur Node 24, puis construit l'image Docker (`linux/amd64`, sans push) et vérifie qu'elle
+démarre — à chaque push sur `main` et sur chaque pull request.
 
 Le workflow n'a besoin d'**aucun secret** : la suite de tests n'ouvre aucune connexion IMAP ou SMTP
 et force `ENABLE_SENDING=false`. Il n'y a donc pas de compte iCloud à configurer dans le dépôt, et
 une pull request extérieure ne peut rien exfiltrer.
+
+Les versions sont publiées par [`.github/workflows/release.yml`](../.github/workflows/release.yml)
+sur tag `vX.Y.Z` : image poussée sur GHCR et GitHub Release. Procédure détaillée dans
+[`CHANGELOG.md`](../CHANGELOG.md).
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -35,6 +35,9 @@ verrouillé par des tests.
 
 **Un rate limit sur `/mcp`.** Fenêtre glissante par IP, `429` au-delà de `RATE_LIMIT_PER_MINUTE`,
 placé avant l'authentification pour amortir un brute-force de token. `/health` n'est pas limité.
+Derrière le tunnel, l'IP retenue est celle de l'en-tête `CF-Connecting-IP` (posée par `cloudflared`,
+non usurpable par le client), pas l'IP du conteneur `cloudflared` — sans quoi tout le trafic
+partagerait un seul seau.
 
 **Un TTL sur les sessions MCP.** Une session abandonnée sans `DELETE` est évincée après
 `SESSION_TTL_MS` d'inactivité et son transport fermé — la `Map` de sessions ne fuit plus.
@@ -89,7 +92,9 @@ C'est la seule chose qui sépare votre boîte mail d'Internet une fois le tunnel
   configuration du client MCP. Toutes les sessions existantes sont invalidées.
 
 `/mcp` est protégé par un **rate limit par IP** (`RATE_LIMIT_PER_MINUTE`, `429` au-delà), placé
-avant l'authentification : un brute-force de token depuis une même IP est ralenti. Il n'y a pas de
+avant l'authentification : un brute-force de token depuis une même IP est ralenti. L'IP est lue dans
+`CF-Connecting-IP` derrière le tunnel (`app.set('trust proxy', true)` : le seul ingress est
+`cloudflared` sur le réseau bridge privé). Il n'y a pas de
 **verrouillage** après échecs répétés. Un token de 32 octets aléatoires rend le brute-force
 inatteignable de toute façon ; un token faible reste faible. Cloudflare Access peut ajouter une
 couche d'authentification devant le tunnel si vous en voulez une. `UNRESTRICTED=true` lève ce rate
@@ -137,7 +142,7 @@ Deux garde-fous à connaître :
 | Endpoint | Authentifié | Ce qu'il révèle |
 |---|---|---|
 | `POST/GET/DELETE /mcp` | oui | Tout, avec un token valide. Rate-limité par IP (`429` au-delà). |
-| `GET /health` | **non** | `{"status":"ok"}` uniquement — pas de version, pas de configuration. Jamais rate-limité. |
+| `GET /health` | **non** | `{"status":"ok","version":"<x.y.z>"}` — statut et version du serveur, rien d'autre (aucune configuration, aucun secret). Jamais rate-limité. |
 
 Aucune autre route n'est déclarée : tout le reste renvoie le 404 par défaut d'Express.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -98,7 +98,7 @@ limit — voir la section *Les garde-fous d'envoi*.
 ### Le mot de passe d'application Apple
 
 - Il donne accès à **toute** la boîte mail, pas seulement à ce serveur.
-- Créez-en un **dédié** à mail-mcp : vous pourrez le révoquer sans casser vos autres appareils.
+- Créez-en un **dédié** à icloud-mail-mcp : vous pourrez le révoquer sans casser vos autres appareils.
 - Révocation immédiate sur [appleid.apple.com](https://appleid.apple.com/) → *Connexion et
   sécurité* → *Mots de passe pour applications*, au moindre doute.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "mail-mcp",
+  "name": "icloud-mail-mcp",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mail-mcp",
+      "name": "icloud-mail-mcp",
       "version": "0.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,28 +9,28 @@
       "version": "0.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "html-to-text": "10.0.1",
-        "imapflow": "^1.4.7",
-        "mailparser": "^3.9.14",
-        "nodemailer": "^9.0.3",
+        "imapflow": "^1.7.6",
+        "mailparser": "^3.9.17",
+        "nodemailer": "^9.1.0",
         "pino": "^10.3.1",
-        "zod": "^4.4.3"
+        "zod": "^4.5.4"
       },
       "devDependencies": {
         "@types/express": "^5.0.6",
         "@types/mailparser": "^3.4.6",
         "@types/node": "^24.13.3",
         "@types/nodemailer": "^8.0.1",
-        "@typescript-eslint/eslint-plugin": "^8.19.0",
-        "@typescript-eslint/parser": "^8.19.0",
+        "@typescript-eslint/eslint-plugin": "^8.68.0",
+        "@typescript-eslint/parser": "^8.68.0",
         "eslint": "^9.17.0",
         "eslint-config-prettier": "^9.1.0",
-        "globals": "^17.7.0",
-        "prettier": "^3.4.2",
-        "tsx": "^4.23.1",
+        "globals": "^17.11.0",
+        "prettier": "^3.9.6",
+        "tsx": "^4.23.13",
         "typescript": "^5.7.2"
       },
       "engines": {
@@ -798,12 +798,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1006,17 +1006,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
-      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.68.0.tgz",
+      "integrity": "sha512-WASHDpCm6qO5jj9g1a+8NiW5+GCkAyLReR56/4VruYmNgfUmqpxOfZ2Yfb8xGfJPWv5Qi6LSD8sXdces3vbp/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/type-utils": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/scope-manager": "8.68.0",
+        "@typescript-eslint/type-utils": "8.68.0",
+        "@typescript-eslint/utils": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1029,22 +1029,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.64.0",
+        "@typescript-eslint/parser": "^8.68.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
-      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.68.0.tgz",
+      "integrity": "sha512-fHq2VC1kpyYfvEcbiMjOpySY4WS7voEp89yAThrHRX5sm9j2lzYppCb2umFMEed4fWcyeLjHxrz0mpjNBaBxMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/scope-manager": "8.68.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1060,14 +1060,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
-      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.68.0.tgz",
+      "integrity": "sha512-5GQtWZCXFcFYux955pvoS02WLc49pXNlvIxocKjS0clvwo3in1RdlzVKyiqQH9vE5AKWFLTaUgeQkOrTS+0Qxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.64.0",
-        "@typescript-eslint/types": "^8.64.0",
+        "@typescript-eslint/tsconfig-utils": "^8.68.0",
+        "@typescript-eslint/types": "^8.68.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1082,14 +1082,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
-      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.68.0.tgz",
+      "integrity": "sha512-T5eXpcaJNg8bhjHJ8Rjp68Vq/QBteYtTKY8TZqVNPaUbuz0f6jI9t6aDkylwvalpAB9XTTFeFOjrjXAZ3YvmVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0"
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1100,9 +1100,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
-      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.68.0.tgz",
+      "integrity": "sha512-F7zrGQfiJHojPwi8vhxZQC1tWtJzvL74cK/nqri2lk8YUXvYaYwl263xOJ69jDWPUk1hmcdoayFwk9lX09npVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1117,15 +1117,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
-      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.68.0.tgz",
+      "integrity": "sha512-X77zqoY1EjeWGs/0JNxeaMfp5C5lIz4Tw8y66F1Ne8Faq6g424sBNYM6xBAqElfGZPLpWS+CZAp0DXyKDzWiHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0",
+        "@typescript-eslint/utils": "8.68.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1142,9 +1142,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
-      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.68.0.tgz",
+      "integrity": "sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1156,16 +1156,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
-      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.68.0.tgz",
+      "integrity": "sha512-OKKsD0tYmoNiU5PW2zehO1yO56jYOm1ShYlxon/Z0SJNidAkdVg86eg9ruRuoXf8xfnuWZGbwDsStkoXbZtIIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.64.0",
-        "@typescript-eslint/tsconfig-utils": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/project-service": "8.68.0",
+        "@typescript-eslint/tsconfig-utils": "8.68.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1184,16 +1184,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
-      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.68.0.tgz",
+      "integrity": "sha512-PB5gJMMOg0Q5P1tsgWtEAqQacJXq0qEqRHDX/YJ4FaTMLfZPpHB3gjl2EJuiZyPABxmj4ZQYiY9m1bdAJ5y7tQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0"
+        "@typescript-eslint/scope-manager": "8.68.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1208,13 +1208,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
-      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.68.0.tgz",
+      "integrity": "sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/types": "8.68.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1239,13 +1239,13 @@
       }
     },
     "node_modules/@zone-eu/mailsplit": {
-      "version": "5.4.14",
-      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.14.tgz",
-      "integrity": "sha512-rz0FQOhN3Vq1XrSeSSa9+dPcaFbBxmQPjiZm6zS9oxdVHV7rOWIAYX3yP2YAUf0qBncY8CI+NogzPCmMVrMXcw==",
+      "version": "5.4.15",
+      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.15.tgz",
+      "integrity": "sha512-c7ZpxauvF4AEkDJlKDYO7iMUtMuqJMBnDWNff1cyx+d7zaBVR3iFEmXhNHOVoMmVyVF3pTZLsLIJsEFKDldOAA==",
       "license": "(MIT OR EUPL-1.1+)",
       "dependencies": {
         "libbase64": "1.3.0",
-        "libmime": "5.4.1",
+        "libmime": "5.4.2",
         "libqp": "2.1.1"
       }
     },
@@ -2402,9 +2402,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
-      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2575,18 +2575,17 @@
       }
     },
     "node_modules/imapflow": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.4.7.tgz",
-      "integrity": "sha512-nK03WfN16inwm0//0Q70T21G0g4H9ArMVyzKDRjAshOVV8iw71PP9HTpAXNmWB9giZWfPiS+ltHByi37cqwSgg==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.7.6.tgz",
+      "integrity": "sha512-xah3HpJKHzNbO780jy+v/Gjmly9WBgPH2dl5/nNs+Q5ofjpn4bUTz0PR2kcrHGlBRsjGFOC7NTYkStakGN8Fyg==",
       "license": "MIT",
       "dependencies": {
-        "@zone-eu/mailsplit": "5.4.14",
+        "@zone-eu/mailsplit": "5.4.15",
         "encoding-japanese": "2.2.0",
         "iconv-lite": "0.7.3",
         "libbase64": "1.3.0",
-        "libmime": "5.4.1",
+        "libmime": "5.4.2",
         "libqp": "2.1.1",
-        "nodemailer": "9.0.3",
         "pino": "10.3.1",
         "socks": "2.8.9"
       }
@@ -2775,9 +2774,9 @@
       "license": "MIT"
     },
     "node_modules/libmime": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.4.1.tgz",
-      "integrity": "sha512-0wHGhsofo9IdQPenr3BBHXuxcwMq4atFUTsZ9Ogc1OvI5h4rUdDIrBQEN9JHjCXfDMrE59LUMJWsTD82wTYk8A==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.4.2.tgz",
+      "integrity": "sha512-+IQnCOdPiufGBkOii+Ze8F7iniyBzOwvWDbn1DyExBpc9pT2B3IEMQi7GUc/PpqhNUh/sr1SG9UXDITQoR0VIA==",
       "license": "MIT",
       "dependencies": {
         "encoding-japanese": "2.2.0",
@@ -2835,50 +2834,27 @@
       "license": "MIT"
     },
     "node_modules/mailparser": {
-      "version": "3.9.15",
-      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.15.tgz",
-      "integrity": "sha512-/5hgybKDMKFS05jAh8OPeEE7N53lj8nF6ywlo89VPjF2TtwqIQbjaxumQWnJIkmaagnJ6u1eansMOViHFxIXwQ==",
+      "version": "3.9.17",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.17.tgz",
+      "integrity": "sha512-ELSD5aeFPS/1227UqkmbbmBqy4SFpvADYTbVImQ5m8KoM7ZLG3PcnHF6+16MTgg2AeNGIcKzfBW8n6XrHZJGeg==",
       "license": "MIT",
       "dependencies": {
         "@zone-eu/mailsplit": "5.4.15",
         "encoding-japanese": "2.2.0",
         "he": "1.2.0",
-        "html-to-text": "10.0.0",
+        "html-to-text": "10.0.1",
         "iconv-lite": "0.7.3",
         "libmime": "5.4.2",
         "linkify-it": "5.0.2",
-        "nodemailer": "9.0.5",
+        "nodemailer": "9.0.6",
         "punycode.js": "2.3.1",
         "tlds": "1.261.0"
       }
     },
-    "node_modules/mailparser/node_modules/@zone-eu/mailsplit": {
-      "version": "5.4.15",
-      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.15.tgz",
-      "integrity": "sha512-c7ZpxauvF4AEkDJlKDYO7iMUtMuqJMBnDWNff1cyx+d7zaBVR3iFEmXhNHOVoMmVyVF3pTZLsLIJsEFKDldOAA==",
-      "license": "(MIT OR EUPL-1.1+)",
-      "dependencies": {
-        "libbase64": "1.3.0",
-        "libmime": "5.4.2",
-        "libqp": "2.1.1"
-      }
-    },
-    "node_modules/mailparser/node_modules/libmime": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.4.2.tgz",
-      "integrity": "sha512-+IQnCOdPiufGBkOii+Ze8F7iniyBzOwvWDbn1DyExBpc9pT2B3IEMQi7GUc/PpqhNUh/sr1SG9UXDITQoR0VIA==",
-      "license": "MIT",
-      "dependencies": {
-        "encoding-japanese": "2.2.0",
-        "iconv-lite": "0.7.3",
-        "libbase64": "1.3.0",
-        "libqp": "2.1.1"
-      }
-    },
     "node_modules/mailparser/node_modules/nodemailer": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.5.tgz",
-      "integrity": "sha512-wvjiKvjczmsN7U/8006JOdXubgBk2XFAbioDMbT+sM7cPs0QrhJTa6KBRX7P5REGGkDcLUz/EarWidb8G8C1jQ==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.6.tgz",
+      "integrity": "sha512-IQUGFdhdGwI9+AWX+FpUt4DLmvFaOjTMEoneTIWX/RXxuy1TdenPwWrvFMSfLkPKl+HQEXWuSAxEMMbPYXtBmg==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -2940,13 +2916,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2978,9 +2954,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
-      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.1.0.tgz",
+      "integrity": "sha512-xj1Ri5Sau3qpPffHJwi2bY0oWVVWYq62Ph17l+2v1xXpxjqTls3YPc3L8dub9mcJpxj+1ucNnuYVqLlgh4pmDA==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -3161,9 +3137,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3230,9 +3206,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
-      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3715,9 +3691,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
-      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "version": "4.23.13",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.13.tgz",
+      "integrity": "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3877,9 +3853,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -21,15 +21,15 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "html-to-text": "10.0.1",
-    "imapflow": "^1.4.7",
-    "mailparser": "^3.9.14",
-    "nodemailer": "^9.0.3",
+    "imapflow": "^1.7.6",
+    "mailparser": "^3.9.17",
+    "nodemailer": "^9.1.0",
     "pino": "^10.3.1",
-    "zod": "^4.4.3"
+    "zod": "^4.5.4"
   },
   "overrides": {
     "html-to-text": "10.0.1"
@@ -37,15 +37,15 @@
   "devDependencies": {
     "@types/express": "^5.0.6",
     "@types/mailparser": "^3.4.6",
-    "@types/nodemailer": "^8.0.1",
     "@types/node": "^24.13.3",
-    "@typescript-eslint/eslint-plugin": "^8.19.0",
-    "@typescript-eslint/parser": "^8.19.0",
+    "@types/nodemailer": "^8.0.1",
+    "@typescript-eslint/eslint-plugin": "^8.68.0",
+    "@typescript-eslint/parser": "^8.68.0",
     "eslint": "^9.17.0",
     "eslint-config-prettier": "^9.1.0",
-    "globals": "^17.7.0",
-    "prettier": "^3.4.2",
-    "tsx": "^4.23.1",
+    "globals": "^17.11.0",
+    "prettier": "^3.9.6",
+    "tsx": "^4.23.13",
     "typescript": "^5.7.2"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mail-mcp",
+  "name": "icloud-mail-mcp",
   "private": true,
   "version": "0.1.0",
   "description": "MCP server exposing iCloud Mail (IMAP/SMTP) as tools for Claude",

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -130,7 +130,7 @@ async function runCheck(): Promise<void> {
 }
 
 async function runSetup(): Promise<void> {
-  console.log('Configuration de mail-mcp\n');
+  console.log('Configuration de icloud-mail-mcp\n');
 
   const email = (await ask('Adresse iCloud (Apple ID) : ')).trim();
   if (email === '') {

--- a/src/http/client-ip.ts
+++ b/src/http/client-ip.ts
@@ -1,0 +1,26 @@
+import type { Request } from 'express';
+
+/**
+ * IP réelle de l'appelant.
+ *
+ * Le déploiement de référence place `cloudflared` en unique point d'entrée, sur
+ * le réseau bridge privé : sans traitement, toutes les requêtes portent l'IP du
+ * conteneur `cloudflared` et le rate limit par IP s'effondre en un seul seau.
+ *
+ * `cloudflared` renseigne `CF-Connecting-IP` avec l'IP vue par l'edge Cloudflare.
+ * Un client ne peut pas l'usurper : l'edge écrase toute valeur entrante. On la
+ * privilégie (valeur unique, pas de parsing), puis on retombe sur `req.ip` —
+ * résolu depuis `X-Forwarded-For` quand `trust proxy` est actif — puis sur l'IP
+ * de socket.
+ *
+ * Le seul cas où cette valeur redevient usurpable est l'exposition directe du
+ * port (section « Tester en local » du guide de déploiement), déjà signalée
+ * comme à ne pas laisser en place.
+ */
+export function clientIp(req: Request): string {
+  const cfConnectingIp = req.headers['cf-connecting-ip'];
+  if (typeof cfConnectingIp === 'string' && cfConnectingIp.trim().length > 0) {
+    return cfConnectingIp.trim();
+  }
+  return req.ip ?? req.socket.remoteAddress ?? 'unknown';
+}

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -5,9 +5,11 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { createMailMcpServer } from '../mcp/server.js';
 import { bearerAuth } from './auth.js';
+import { clientIp } from './client-ip.js';
 import { SlidingWindowRateLimiter } from './rate-limit.js';
 import { config } from '../config.js';
 import { logger } from '../logger.js';
+import { serverVersion } from '../version.js';
 
 const log = logger.child({ module: 'http' });
 
@@ -81,7 +83,7 @@ export function createHttpServer(options: HttpServerOptions = {}): HttpServer {
       next();
       return;
     }
-    const key = req.ip ?? req.socket.remoteAddress ?? 'unknown';
+    const key = clientIp(req);
     if (!rateLimiter.allow(key)) {
       log.warn({ ip: key }, 'rate limit exceeded on /mcp');
       res.status(429).json({
@@ -151,6 +153,10 @@ export function createHttpServer(options: HttpServerOptions = {}): HttpServer {
   }
 
   const app = express();
+  // Le seul ingress est cloudflared, sur le réseau bridge privé : on lui fait
+  // confiance pour X-Forwarded-For afin que req.ip porte l'IP cliente. La
+  // résolution fine passe par clientIp() (CF-Connecting-IP en priorité).
+  app.set('trust proxy', true);
   app.use(express.json());
 
   app.post('/mcp', rateLimit, bearerAuth, handlePost);
@@ -158,7 +164,7 @@ export function createHttpServer(options: HttpServerOptions = {}): HttpServer {
   app.delete('/mcp', rateLimit, bearerAuth, handleSessionRequest);
 
   app.get('/health', (_req, res) => {
-    res.json({ status: 'ok' });
+    res.json({ status: 'ok', version: serverVersion });
   });
 
   async function close(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ const cleanups: Array<() => void | Promise<void>> = [];
 if (useHttp) {
   const http = createHttpServer();
   const httpServer: Server = http.app.listen(config.PORT, '0.0.0.0', () => {
-    logger.info({ port: config.PORT }, 'mail-mcp http server listening');
+    logger.info({ port: config.PORT }, 'icloud-mail-mcp http server listening');
   });
   cleanups.push(() => {
     httpServer.close();
@@ -33,7 +33,7 @@ if (useStdio) {
   await server.connect(transport);
   cleanups.push(() => transport.close());
   // stderr : en stdio, stdout est le canal JSON-RPC (voir src/logger.ts).
-  logger.info('mail-mcp stdio server ready');
+  logger.info('icloud-mail-mcp stdio server ready');
 }
 
 async function shutdown(signal: string): Promise<void> {

--- a/test/auth-cli.test.ts
+++ b/test/auth-cli.test.ts
@@ -16,7 +16,7 @@ import { SmtpAuthError, SmtpNetworkError } from '../src/smtp/errors.js';
 
 // Répertoire jetable : toute écriture de fichier de ce test y reste confinée,
 // jamais sur le .env du dépôt.
-const workdir = mkdtempSync(join(tmpdir(), 'mail-mcp-auth-'));
+const workdir = mkdtempSync(join(tmpdir(), 'icloud-mail-mcp-auth-'));
 after(() => rmSync(workdir, { recursive: true, force: true }));
 
 describe('normalizeAppPassword', () => {

--- a/test/client-ip.test.ts
+++ b/test/client-ip.test.ts
@@ -1,0 +1,53 @@
+import './helpers/env.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Request } from 'express';
+import { clientIp } from '../src/http/client-ip.js';
+
+/** Fabrique un objet assez proche d'un `Request` Express pour `clientIp()`. */
+function fakeRequest(options: {
+  headers?: Record<string, string | string[] | undefined>;
+  ip?: string;
+  remoteAddress?: string;
+}): Request {
+  return {
+    headers: options.headers ?? {},
+    ip: options.ip,
+    socket: { remoteAddress: options.remoteAddress },
+  } as unknown as Request;
+}
+
+describe('clientIp', () => {
+  it('privilégie CF-Connecting-IP', () => {
+    const req = fakeRequest({
+      headers: { 'cf-connecting-ip': '203.0.113.7' },
+      ip: '172.18.0.3',
+      remoteAddress: '172.18.0.3',
+    });
+    assert.equal(clientIp(req), '203.0.113.7');
+  });
+
+  it('trim la valeur de CF-Connecting-IP', () => {
+    const req = fakeRequest({ headers: { 'cf-connecting-ip': '  203.0.113.7  ' } });
+    assert.equal(clientIp(req), '203.0.113.7');
+  });
+
+  it('retombe sur req.ip quand CF-Connecting-IP est absent', () => {
+    const req = fakeRequest({ ip: '198.51.100.42', remoteAddress: '172.18.0.3' });
+    assert.equal(clientIp(req), '198.51.100.42');
+  });
+
+  it('ignore un CF-Connecting-IP vide', () => {
+    const req = fakeRequest({ headers: { 'cf-connecting-ip': '   ' }, ip: '198.51.100.42' });
+    assert.equal(clientIp(req), '198.51.100.42');
+  });
+
+  it('retombe sur remoteAddress quand req.ip est absent', () => {
+    const req = fakeRequest({ remoteAddress: '172.18.0.3' });
+    assert.equal(clientIp(req), '172.18.0.3');
+  });
+
+  it('renvoie "unknown" en dernier recours', () => {
+    assert.equal(clientIp(fakeRequest({})), 'unknown');
+  });
+});

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -6,6 +6,7 @@ import type { Server } from 'node:http';
 import { createHttpServer } from '../src/http/server.js';
 import type { HttpServer } from '../src/http/server.js';
 import { config } from '../src/config.js';
+import { serverVersion } from '../src/version.js';
 import { imapPool } from '../src/imap/pool.js';
 import { closeSmtp } from '../src/smtp/client.js';
 
@@ -70,7 +71,7 @@ describe('GET /health', () => {
   it('répond sans authentification (healthcheck Docker)', async () => {
     const response = await fetch(`${baseUrl}/health`);
     assert.equal(response.status, 200);
-    assert.deepEqual(await response.json(), { status: 'ok' });
+    assert.deepEqual(await response.json(), { status: 'ok', version: serverVersion });
   });
 });
 
@@ -190,6 +191,19 @@ describe('rate limit sur /mcp', () => {
   it('n’applique jamais le rate limit à /health', async () => {
     for (let i = 0; i < 20; i += 1) {
       assert.equal((await fetch(`${url}/health`)).status, 200);
+    }
+  });
+
+  it('compte par CF-Connecting-IP, pas par IP de socket', async () => {
+    // Même socket (localhost), deux IP clientes distinctes derrière le tunnel :
+    // chacune a son propre seau, aucune ne doit déclencher le 429 de l'autre.
+    for (const ip of ['203.0.113.10', '203.0.113.20']) {
+      const statuses: number[] = [];
+      for (let i = 0; i < 3; i += 1) {
+        const res = await fetch(`${url}/mcp`, { method: 'GET', headers: { 'CF-Connecting-IP': ip } });
+        statuses.push(res.status);
+      }
+      assert.deepEqual(statuses, [401, 401, 401], `IP ${ip} ne doit pas être limitée`);
     }
   });
 });


### PR DESCRIPTION
Prépare la première version publiable. Détail dans `CHANGELOG.md`.

## Contenu

- **Renommage** `mail-mcp` → `icloud-mail-mcp` (l'id du serveur MCP reste `icloud-mail`, aucune config client à changer).
- **Déploiement par image publiée** : `docker-compose.yml` tire `ghcr.io/leolesimple/icloud-mail-mcp` au tag `ICLOUD_MAIL_MCP_VERSION` ; `docker-compose.dev.yml` pour le build local ; `cloudflared` attend le healthcheck.
- **`release.yml`** : tag `v*` → vérifie tag == `package.json`, rejoue tests + build, pousse l'image GHCR (`linux/amd64`, tags `X.Y.Z` / `X.Y` / `latest`) et crée la GitHub Release.
- **CI** : job de build + smoke-test de l'image Docker.
- **IP cliente réelle** derrière le tunnel : `trust proxy` + `CF-Connecting-IP`, le rate-limit par IP ne s'effondre plus en un seul seau.
- **`/health`** expose la version (`{"status":"ok","version":"0.1.0"}`).
- Bump des dépendances mineures (0 vuln), `dependabot.yml`, `CHANGELOG.md`, `.env.example` nettoyé.

## Vérifs

`typecheck` + `lint` + 340 tests + `build` verts en local.

## Après merge

1. `gh repo rename icloud-mail-mcp`
2. `git tag -a v0.1.0 -m v0.1.0 && git push origin v0.1.0`
3. Rendre le paquet GHCR public (une fois)
4. Serveur Debian : `.env` + `docker compose up -d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)