### PR TITLE
Déploiement : externaliser le tunnel + release 0.1.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,9 +94,16 @@ ENABLE_IDLE_WATCH=false
 # ("0.1.0") pour epingler, "latest" pour suivre le dernier tag publie.
 ICLOUD_MAIL_MCP_VERSION=latest
 
-# Token du tunnel, genere dans le dashboard Cloudflare Zero Trust
-# (Networks -> Tunnels -> Créer un tunnel -> Docker). Utilise uniquement par
-# le service "cloudflared" du docker-compose.yml, pas par l'app elle-même.
+# Nom du reseau Docker partage avec le cloudflared qui gere le tunnel (stack
+# tierce, hors de ce projet). Le serveur s'y rattache pour etre joignable en
+# http://icloud-mail-mcp:3000. Le reseau doit deja exister :
+#   docker network create "<ce nom>"
+# REQUIS (docker-compose.yml echoue sans).
+TUNNEL_NETWORK=
+
+# Token du tunnel Cloudflare (dashboard Zero Trust -> Networks -> Tunnels).
+# Utilise UNIQUEMENT par le cloudflared embarque de docker-compose.tunnel.yml
+# (deploiement autonome). Inutile si le tunnel est gere ailleurs.
 TUNNEL_TOKEN=
 
 # --- Logs ---------------------------------------------------------------------

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,21 +3,41 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
-      # Un seul PR par vague de mises à jour mineures/patch.
-      minor-and-patch:
+      # Un seul PR par vague pour les montées mineures/patch.
+      npm-minor-patch:
+        patterns:
+          - "*"
         update-types:
           - minor
           - patch
-    open-pull-requests-limit: 5
+    ignore:
+      # Majeures qui demandent une migration dédiée, pas un bump automatique.
+      # (Les autres majeures restent proposées, une par PR, pour revue.)
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
+      - dependency-name: eslint
+        update-types: ["version-update:semver-major"]
+      - dependency-name: eslint-config-prettier
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
+    groups:
+      actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: docker
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
+    groups:
+      docker:
+        patterns:
+          - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,14 @@ versionnage [SemVer](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
-_Rien pour l'instant._
+### Modifié
+
+- **Déploiement : tunnel externalisable.** `docker-compose.yml` ne contient plus
+  que le serveur, rattaché à un réseau Docker externe dont le nom vit dans `.env`
+  (`TUNNEL_NETWORK`) — pour un `cloudflared` géré par une autre stack. Le
+  `cloudflared` embarqué passe dans `docker-compose.tunnel.yml` (déploiement
+  autonome, opt-in). `docs/deployment.md` réécrit : installation en 2 fichiers
+  `curl`, sans `git clone`.
 
 ## [0.1.0] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ versionnage [SemVer](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+_Rien pour l'instant._
+
+## [0.1.1] - 2026-08-31
+
 ### Modifié
 
 - **Déploiement : tunnel externalisable.** `docker-compose.yml` ne contient plus
@@ -67,5 +71,6 @@ Première version publiée. Serveur MCP exposant un compte iCloud Mail
   par IP ne s'effondre plus en un seul seau).
 - Dependabot sur npm et GitHub Actions.
 
-[Non publié]: https://github.com/leolesimple/icloud-mail-mcp/compare/v0.1.0...HEAD
+[Non publié]: https://github.com/leolesimple/icloud-mail-mcp/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/leolesimple/icloud-mail-mcp/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/leolesimple/icloud-mail-mcp/releases/tag/v0.1.0

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,8 +1,9 @@
 # Surcharge pour le développement local : construit l'image depuis les sources
-# au lieu de tirer celle de GHCR, et publie le port sur l'hôte pour viser
-# http://localhost:3000 sans tunnel.
+# au lieu de tirer celle de GHCR, publie le port sur l'hôte, et remplace le
+# réseau externe du tunnel par un bridge local (pas de cloudflared en dev).
 #
 #   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+#   curl http://localhost:3000/health
 #
 # À ne pas utiliser sur une machine exposée : le port devient joignable
 # directement, hors du tunnel.
@@ -12,3 +13,8 @@ services:
     image: icloud-mail-mcp:dev
     ports:
       - "3000:3000"
+
+networks:
+  tunnel:
+    external: false
+    name: icloud-mail-mcp-dev

--- a/docker-compose.tunnel.yml
+++ b/docker-compose.tunnel.yml
@@ -1,0 +1,20 @@
+# Déploiement autonome : embarque un cloudflared dédié, sur le même réseau que
+# le serveur. À utiliser quand aucun tunnel n'est déjà géré ailleurs.
+#
+#   docker network create "$TUNNEL_NETWORK"   # une fois, si le réseau n'existe pas
+#   docker compose -f docker-compose.yml -f docker-compose.tunnel.yml up -d
+#
+# Renseigner TUNNEL_TOKEN dans .env (dashboard Cloudflare Zero Trust).
+services:
+  cloudflared:
+    image: cloudflare/cloudflared:2025.2
+    container_name: icloud-mail-mcp-cloudflared
+    command: tunnel --no-autoupdate run --token ${TUNNEL_TOKEN:?TUNNEL_TOKEN manquant dans .env} --url http://icloud-mail-mcp:3000
+    restart: unless-stopped
+    # Le HEALTHCHECK est porté par l'image : on n'ouvre le tunnel qu'une fois le
+    # serveur prêt à répondre sur /health.
+    depends_on:
+      icloud-mail-mcp:
+        condition: service_healthy
+    networks:
+      - tunnel

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,21 +9,16 @@ services:
       - .env
     restart: unless-stopped
     networks:
-      - icloud-mail-mcp-net
+      - tunnel
 
-  cloudflared:
-    image: cloudflare/cloudflared:2025.2
-    container_name: icloud-mail-mcp-cloudflared
-    command: tunnel --no-autoupdate run --token ${TUNNEL_TOKEN} --url http://icloud-mail-mcp:3000
-    restart: unless-stopped
-    # Le HEALTHCHECK est porté par l'image : on n'ouvre le tunnel qu'une fois le
-    # serveur prêt à répondre sur /health.
-    depends_on:
-      icloud-mail-mcp:
-        condition: service_healthy
-    networks:
-      - icloud-mail-mcp-net
-
+# Réseau partagé avec le cloudflared qui expose le tunnel. Ce cloudflared est
+# géré hors de ce projet (stack tierce) ; le serveur y est simplement rattaché,
+# joignable en `http://icloud-mail-mcp:3000`. Le nom du réseau vit dans .env
+# (TUNNEL_NETWORK) pour ne pas être commité, et le réseau doit déjà exister :
+#   docker network create "$TUNNEL_NETWORK"   # si ce n'est pas déjà le cas
+#
+# Déploiement autonome (cloudflared embarqué) : ajouter docker-compose.tunnel.yml.
 networks:
-  icloud-mail-mcp-net:
-    driver: bridge
+  tunnel:
+    external: true
+    name: ${TUNNEL_NETWORK:?définir TUNNEL_NETWORK dans .env (nom du réseau Docker partagé avec cloudflared)}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,10 +207,12 @@ un throttling iCloud.
 
 ---
 
-## Cloudflare Tunnel
+## Déploiement (docker-compose)
 
 | Variable | Requis | Description |
 |---|---|---|
-| `TUNNEL_TOKEN` | pour le déploiement | Token du tunnel, utilisé uniquement par le service `cloudflared` du `docker-compose.yml` |
+| `ICLOUD_MAIL_MCP_VERSION` | non (`latest`) | Tag de l'image GHCR tirée par `docker-compose.yml` |
+| `TUNNEL_NETWORK` | oui | Nom du réseau Docker partagé avec le `cloudflared` qui gère le tunnel. Le réseau doit déjà exister. |
+| `TUNNEL_TOKEN` | modèle autonome | Token du tunnel Cloudflare, utilisé uniquement par le `cloudflared` embarqué de `docker-compose.tunnel.yml` |
 
-L'application elle-même ne lit jamais cette variable. Voir [deployment.md](deployment.md).
+L'application elle-même ne lit aucune de ces variables. Voir [deployment.md](deployment.md).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,47 +1,56 @@
 # Déploiement
 
-Le déploiement de référence : deux conteneurs sur un réseau bridge privé, **aucun port publié sur
-l'hôte**, et un Cloudflare Tunnel qui expose le endpoint en HTTPS sans ouvrir de port sur votre
-routeur.
+Le serveur ne publie **aucun port sur l'hôte**. Il est joint via un `cloudflared` qui établit une
+connexion *sortante* vers Cloudflare et fait redescendre le trafic HTTPS par ce tunnel — rien à
+ouvrir sur la box, pas d'IP fixe, certificat TLS géré par Cloudflare.
 
 ```
 Internet ──HTTPS──▶ Cloudflare ──tunnel sortant──▶ cloudflared ──http://icloud-mail-mcp:3000──▶ icloud-mail-mcp
-                                                        └──── réseau bridge privé ────┘
+                                                        └──── réseau Docker partagé ────┘
 ```
 
-L'intérêt : la machine hôte n'a aucun port entrant ouvert. `cloudflared` établit une connexion
-*sortante* vers Cloudflare, et le trafic redescend par ce tunnel. Rien à configurer sur la box, pas
-d'IP fixe, certificat TLS géré par Cloudflare.
+Deux modèles :
+
+- **Tunnel géré ailleurs (par défaut).** Un `cloudflared` tourne déjà dans une autre stack ; le
+  serveur se rattache simplement à son réseau Docker. `docker-compose.yml` seul.
+- **Autonome.** Aucun tunnel existant : ajouter `docker-compose.tunnel.yml`, qui embarque un
+  `cloudflared` dédié.
+
+Dans les deux cas, rien n'est compilé sur l'hôte : `docker-compose.yml` tire l'image publiée sur
+`ghcr.io/leolesimple/icloud-mail-mcp` à chaque tag `v*`.
 
 ---
 
-## 1. Créer le tunnel
+## 1. Le réseau et le hostname public
 
-Dans le dashboard [Cloudflare Zero Trust](https://one.dash.cloudflare.com/) :
+Le serveur et `cloudflared` doivent partager un réseau Docker. Son nom vit dans `.env`
+(`TUNNEL_NETWORK`), pas dans le dépôt. Le créer s'il n'existe pas encore :
 
-1. **Networks → Tunnels → Create a tunnel**
-2. Type **Cloudflared**, nommer le tunnel
-3. Choisir l'environnement **Docker** et copier le token affiché (une longue chaîne)
-4. Onglet **Public Hostname** → **Add a public hostname** :
-   - *Subdomain* : `icloud-mail-mcp` (par exemple)
-   - *Domain* : votre domaine
-   - *Service* : **HTTP** → `icloud-mail-mcp:3000`
+```bash
+docker network create tunnel-net    # ou le nom de votre choix
+```
 
-Le service pointe vers le **nom du conteneur**, pas vers `localhost` : les deux conteneurs partagent
-le réseau `icloud-mail-mcp-net` du compose.
+Côté [Cloudflare Zero Trust](https://one.dash.cloudflare.com/), sur le tunnel qui dessert ce
+réseau, **Public Hostname → Add a public hostname** :
+
+- *Subdomain* / *Domain* : à votre convenance
+- *Service* : **HTTP** → `icloud-mail-mcp:3000` (le **nom du conteneur**, résolu sur le réseau
+  partagé — pas `localhost`)
+
+Pour le modèle autonome, récupérer aussi le **token** du tunnel (environnement *Docker*).
 
 ---
 
 ## 2. Préparer l'hôte
 
-Le déploiement ne compile rien sur l'hôte : `docker-compose.yml` tire l'image publiée sur
-`ghcr.io/leolesimple/icloud-mail-mcp` à chaque tag `v*`. Seuls le `docker-compose.yml` et le `.env`
-sont nécessaires — cloner le dépôt reste le plus simple pour les récupérer.
+Deux fichiers suffisent, dans un dossier vide — pas besoin de cloner le dépôt :
 
 ```bash
-git clone https://github.com/leolesimple/icloud-mail-mcp.git
-cd icloud-mail-mcp
-cp .env.example .env
+mkdir icloud-mail-mcp && cd icloud-mail-mcp
+base=https://raw.githubusercontent.com/leolesimple/icloud-mail-mcp/main
+curl -O  $base/docker-compose.yml
+curl -O  $base/docker-compose.tunnel.yml   # seulement pour le modèle autonome
+curl -o .env $base/.env.example
 ```
 
 Renseigner dans `.env` :
@@ -50,21 +59,30 @@ Renseigner dans `.env` :
 ICLOUD_EMAIL=vous@icloud.com
 ICLOUD_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx
 MCP_BEARER_TOKEN=<openssl rand -hex 32>
-TUNNEL_TOKEN=<le token copié à l'étape 1>
-ICLOUD_MAIL_MCP_VERSION=0.1.0   # version à déployer ("latest" pour suivre le dernier tag)
-ENABLE_SENDING=false            # à laisser à false pour la première mise en service
+TUNNEL_NETWORK=tunnel-net              # le réseau de l'étape 1
+ICLOUD_MAIL_MCP_VERSION=0.1.0          # version à déployer ("latest" pour suivre le dernier tag)
+ENABLE_SENDING=false                   # à laisser à false pour la première mise en service
+# TUNNEL_TOKEN=...                     # modèle autonome uniquement
 ```
+
+`docker compose` lit ce `.env` **à la fois** pour les `${VARIABLES}` du compose et pour l'`env` du
+conteneur (`env_file`). Un seul fichier.
 
 ---
 
 ## 3. Lancer
 
+Tunnel géré ailleurs :
+
 ```bash
 docker compose up -d
 ```
 
-`docker compose` tire l'image GHCR puis démarre les deux conteneurs. `cloudflared` attend que
-`icloud-mail-mcp` soit *healthy* avant d'ouvrir le tunnel.
+Autonome (cloudflared embarqué) :
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.tunnel.yml up -d
+```
 
 > Le paquet GHCR est privé par défaut à la première publication. Une fois : le rendre public
 > (*Packages → icloud-mail-mcp → Package settings → Change visibility*), ou, pour le garder privé,
@@ -74,14 +92,8 @@ docker compose up -d
 Vérifier :
 
 ```bash
-docker compose ps                          # les deux conteneurs "healthy"/"running"
+docker compose ps                          # "healthy"/"running"
 docker compose logs -f icloud-mail-mcp     # "icloud-mail-mcp http server listening"
-docker compose logs -f cloudflared         # "Registered tunnel connection"
-```
-
-Puis, depuis n'importe où :
-
-```bash
 curl https://icloud-mail-mcp.exemple.com/health
 # {"status":"ok","version":"0.1.0"}
 ```
@@ -104,8 +116,9 @@ via `env_file`. L'image ne contient donc aucun secret.
 
 ### Tester en local (build depuis les sources)
 
-`docker-compose.dev.yml` surcharge le service : build local au lieu du pull GHCR, et port publié
-sur l'hôte.
+`docker-compose.dev.yml` surcharge le service : build local au lieu du pull GHCR, port publié sur
+l'hôte, et le réseau externe du tunnel remplacé par un bridge local (pas de `cloudflared` ni de
+`TUNNEL_NETWORK` requis).
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
@@ -184,18 +197,18 @@ rapide de distinguer un problème de serveur d'un problème de modèle.
 
 ---
 
-## Mise à jour
+## Mise à jour et retour arrière
 
-Bumper `ICLOUD_MAIL_MCP_VERSION` dans `.env` vers le nouveau tag, puis :
+Bumper `ICLOUD_MAIL_MCP_VERSION` dans `.env` vers le tag voulu, puis :
 
 ```bash
-docker compose pull
-docker compose up -d
+docker compose pull && docker compose up -d
+# modèle autonome : ajouter -f docker-compose.yml -f docker-compose.tunnel.yml aux deux commandes
 ```
 
-Rien à compiler sur l'hôte, rien à `git pull` sauf si `docker-compose.yml` lui-même a changé.
-Revenir en arrière = remettre l'ancienne valeur et rejouer les deux commandes. Vérifier la version
-réellement en ligne : `curl https://icloud-mail-mcp.exemple.com/health`.
+Rien à compiler, rien à re-télécharger sauf si un `docker-compose*.yml` a changé (re-`curl` dans ce
+cas). **Retour arrière** = remettre l'ancienne valeur et rejouer. Vérifier la version réellement en
+ligne : `curl https://icloud-mail-mcp.exemple.com/health`.
 
 Les sessions MCP en cours sont perdues au redémarrage ; les clients en rouvrent une automatiquement
 au prochain appel.
@@ -209,7 +222,9 @@ au prochain appel.
 | `Configuration invalide` au démarrage | Une variable manque ou est mal formée — le message liste précisément lesquelles. |
 | `Authentification iCloud IMAP refusée` | Mot de passe principal utilisé à la place d'un mot de passe d'application, ou mot de passe révoqué. |
 | `401` sur `/mcp`, `/health` OK | Token absent ou différent de `MCP_BEARER_TOKEN`. Vérifier le préfixe `Bearer ` et l'absence d'espace parasite. |
-| `502` Cloudflare | Le conteneur `icloud-mail-mcp` est arrêté, ou le hostname public pointe vers le mauvais port/nom de service. |
+| `502` Cloudflare | Le conteneur `icloud-mail-mcp` est arrêté, hors du réseau `TUNNEL_NETWORK`, ou le hostname public pointe vers le mauvais nom/port de service. |
+| `network <nom> declared as external, but could not be found` | Le réseau n'existe pas : `docker network create "<nom>"`, ou `TUNNEL_NETWORK` ne correspond pas au réseau du `cloudflared`. |
+| `required variable TUNNEL_NETWORK is missing` | `TUNNEL_NETWORK` absent de `.env`. |
 | Erreurs IMAP intermittentes | Throttling iCloud. Baisser `IMAP_POOL_SIZE`, ou espacer les appels. |
-| Le tunnel ne se connecte pas | `TUNNEL_TOKEN` invalide ou tunnel supprimé côté Cloudflare. |
+| Le tunnel ne se connecte pas (modèle autonome) | `TUNNEL_TOKEN` invalide ou tunnel supprimé côté Cloudflare. |
 | En stdio, le client MCP n'obtient jamais de réponse | Quelque chose écrit sur stdout du processus (wrapper qui fait `2>&1`, `console.log` ajouté, autre lib bavarde). stdout est réservé au JSON-RPC. |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -60,7 +60,7 @@ ICLOUD_EMAIL=vous@icloud.com
 ICLOUD_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx
 MCP_BEARER_TOKEN=<openssl rand -hex 32>
 TUNNEL_NETWORK=tunnel-net              # le réseau de l'étape 1
-ICLOUD_MAIL_MCP_VERSION=0.1.0          # version à déployer ("latest" pour suivre le dernier tag)
+ICLOUD_MAIL_MCP_VERSION=0.1.1          # version à déployer ("latest" pour suivre le dernier tag)
 ENABLE_SENDING=false                   # à laisser à false pour la première mise en service
 # TUNNEL_TOKEN=...                     # modèle autonome uniquement
 ```
@@ -95,7 +95,7 @@ Vérifier :
 docker compose ps                          # "healthy"/"running"
 docker compose logs -f icloud-mail-mcp     # "icloud-mail-mcp http server listening"
 curl https://icloud-mail-mcp.exemple.com/health
-# {"status":"ok","version":"0.1.0"}
+# {"status":"ok","version":"0.1.1"}
 ```
 
 Le `/health` répond sans token — c'est voulu, le healthcheck Docker en a besoin. Il ne révèle que le

--- a/docs/security.md
+++ b/docs/security.md
@@ -94,7 +94,7 @@ C'est la seule chose qui sépare votre boîte mail d'Internet une fois le tunnel
 `/mcp` est protégé par un **rate limit par IP** (`RATE_LIMIT_PER_MINUTE`, `429` au-delà), placé
 avant l'authentification : un brute-force de token depuis une même IP est ralenti. L'IP est lue dans
 `CF-Connecting-IP` derrière le tunnel (`app.set('trust proxy', true)` : le seul ingress est
-`cloudflared` sur le réseau bridge privé). Il n'y a pas de
+`cloudflared`, sur le réseau Docker partagé, aucun port publié sur l'hôte). Il n'y a pas de
 **verrouillage** après échecs répétés. Un token de 32 octets aléatoires rend le brute-force
 inatteignable de toute façon ; un token faible reste faible. Cloudflare Access peut ajouter une
 couche d'authentification devant le tunnel si vous en voulez une. `UNRESTRICTED=true` lève ce rate

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -44,7 +44,7 @@ seul un booléen « configuré » est exposé à leur sujet.
 
 ```jsonc
 {
-  "server": { "name": "icloud-mail", "version": "0.1.0" },
+  "server": { "name": "icloud-mail", "version": "0.1.1" },
   "account": {
     "email": "vous@icloud.com",
     "imap": { "host": "imap.mail.me.com", "port": 993 },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "icloud-mail-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "icloud-mail-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "icloud-mail-mcp",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MCP server exposing iCloud Mail (IMAP/SMTP) as tools for Claude",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Contenu

- **`docker-compose.yml`** ne contient plus que le service `icloud-mail-mcp`, rattaché à un réseau Docker **externe** dont le nom vit dans `.env` (`TUNNEL_NETWORK`, non gitté) — pour un `cloudflared` géré par une autre stack, joignable en `http://icloud-mail-mcp:3000`.
- **`docker-compose.tunnel.yml`** : overlay opt-in qui embarque un `cloudflared` dédié (déploiement autonome).
- **`docker-compose.dev.yml`** : remplace le réseau externe par un bridge local, publie le port sur l'hôte — ni `cloudflared` ni `TUNNEL_NETWORK` requis.
- **`docs/deployment.md`** réécrit : installation en 2 fichiers `curl` sans `git clone`, 2 modèles (tunnel géré / autonome), rollback par bump de version.
- **Release 0.1.1** : `package.json` → `0.1.1`, `CHANGELOG` daté, `/health` + `whoami` reportent `0.1.1`.

## Vérifs

`typecheck` + `lint` + 340 tests + `build` verts. Les 3 combinaisons compose validées via `docker compose config`.

## Après merge

`git tag -a v0.1.1 -m v0.1.1 && git push origin v0.1.1` → `release.yml` (image GHCR `0.1.1`/`0.1`/`latest` + GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)