### PR TITLE
Auth : accepter X-Api-Key (connecteurs claude.ai) + release 0.1.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,8 +44,10 @@ PORT=3000
 # Surchargeable par appel via le parametre maxBodyChars.
 MAX_BODY_CHARS=20000
 
-# Token statique requis dans le header "Authorization: Bearer <token>" pour
-# tout appel au endpoint /mcp. Genere avec : openssl rand -hex 32
+# Token statique requis pour tout appel au endpoint /mcp, dans le header
+# "Authorization: Bearer <token>" ou "X-Api-Key: <token>" (jeton brut, pour les
+# connecteurs claude.ai qui interdisent Authorization). Genere avec :
+#   openssl rand -hex 32
 MCP_BEARER_TOKEN=
 
 # Requetes /mcp autorisees par IP et par minute (fenetre glissante). Au-dela : 429.

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 *.log
 .DS_Store
 CLAUDE.md
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ versionnage [SemVer](https://semver.org/lang/fr/).
 
 _Rien pour l'instant._
 
+## [0.1.2] - 2026-08-31
+
+### Ajouté
+
+- **Auth par `X-Api-Key`.** `/mcp` accepte le token en `X-Api-Key: <token>`
+  (jeton brut) en plus de `Authorization: Bearer <token>`. Les connecteurs
+  personnalisés de claude.ai interdisent l'en-tête `Authorization` et n'ouvrent
+  qu'une liste blanche de noms d'en-têtes, dont `x-api-key`. Même token, même
+  accès. `docs/deployment.md` détaille le branchement claude.ai / Claude Desktop.
+
 ## [0.1.1] - 2026-08-31
 
 ### Modifié
@@ -71,6 +81,7 @@ Première version publiée. Serveur MCP exposant un compte iCloud Mail
   par IP ne s'effondre plus en un seul seau).
 - Dependabot sur npm et GitHub Actions.
 
-[Non publié]: https://github.com/leolesimple/icloud-mail-mcp/compare/v0.1.1...HEAD
+[Non publié]: https://github.com/leolesimple/icloud-mail-mcp/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/leolesimple/icloud-mail-mcp/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/leolesimple/icloud-mail-mcp/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/leolesimple/icloud-mail-mcp/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -124,8 +124,9 @@ Puis démarrer :
 npm run dev            # http://localhost:3000/mcp
 ```
 
-Le endpoint MCP est `POST|GET|DELETE /mcp`, protégé par
-`Authorization: Bearer <MCP_BEARER_TOKEN>`. `GET /health` reste ouvert (healthcheck Docker).
+Le endpoint MCP est `POST|GET|DELETE /mcp`, protégé par le `MCP_BEARER_TOKEN`
+(`Authorization: Bearer <token>` ou `X-Api-Key: <token>`). `GET /health` reste ouvert
+(healthcheck Docker).
 
 Pour l'inspecter à la main :
 
@@ -164,7 +165,7 @@ ICLOUD_EMAIL=vous@icloud.com
 ICLOUD_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx
 MCP_BEARER_TOKEN=<openssl rand -hex 32>
 TUNNEL_NETWORK=<réseau Docker partagé avec cloudflared>   # requis
-ICLOUD_MAIL_MCP_VERSION=0.1.1                             # ou "latest"
+ICLOUD_MAIL_MCP_VERSION=0.1.2                             # ou "latest"
 ```
 
 Le trafic passe par un **Cloudflare Tunnel** : `docker-compose.yml` rattache le
@@ -191,8 +192,12 @@ claude mcp add --transport http icloud-mail-mcp https://icloud-mail-mcp.exemple.
   --header "Authorization: Bearer <votre token>"
 ```
 
-**Claude Desktop / claude.ai** : *Paramètres → Connecteurs → Ajouter un connecteur personnalisé*,
-en donnant l'URL `https://icloud-mail-mcp.exemple.com/mcp`.
+**Claude Desktop** : dans `claude_desktop_config.json`, un serveur `"type": "http"` avec
+`"headers": { "Authorization": "Bearer <token>" }`.
+
+**claude.ai (web / mobile)** : *Paramètres → Connecteurs → Ajouter un connecteur personnalisé*,
+URL `https://icloud-mail-mcp.exemple.com/mcp`. Le formulaire interdit l'en-tête `Authorization` :
+choisir **`x-api-key`** avec le **token brut** (le serveur accepte les deux formes).
 
 Détails et dépannage dans [`docs/deployment.md`](docs/deployment.md#brancher-un-client-mcp).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,7 +77,7 @@ En `stdio`, stdout porte le canal JSON-RPC : le serveur bascule automatiquement 
 | Variable | Défaut | Description |
 |---|---|---|
 | `PORT` | `3000` | Port d'écoute. En Docker, port interne au réseau du compose : le conteneur ne l'expose pas à l'hôte. Ignoré si `MCP_TRANSPORT=stdio`. |
-| `MCP_BEARER_TOKEN` | **requis** | Token attendu dans `Authorization: Bearer <token>` sur `/mcp`. 16 caractères minimum. Toujours requis, même en `stdio` (où il ne sert pas). |
+| `MCP_BEARER_TOKEN` | **requis** | Token attendu sur `/mcp`, en `Authorization: Bearer <token>` ou `X-Api-Key: <token>` (jeton brut, pour les connecteurs claude.ai). 16 caractères minimum. Toujours requis, même en `stdio` (où il ne sert pas). |
 | `RATE_LIMIT_PER_MINUTE` | `120` | Requêtes `/mcp` autorisées par IP et par minute (fenêtre glissante). Au-delà : `429`. `/health` n'est jamais limité. |
 | `SESSION_TTL_MS` | `1800000` | Inactivité (en ms) au-delà de laquelle une session MCP est évincée et son transport fermé. 30 min par défaut. |
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -60,7 +60,7 @@ ICLOUD_EMAIL=vous@icloud.com
 ICLOUD_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx
 MCP_BEARER_TOKEN=<openssl rand -hex 32>
 TUNNEL_NETWORK=tunnel-net              # le réseau de l'étape 1
-ICLOUD_MAIL_MCP_VERSION=0.1.1          # version à déployer ("latest" pour suivre le dernier tag)
+ICLOUD_MAIL_MCP_VERSION=0.1.2          # version à déployer ("latest" pour suivre le dernier tag)
 ENABLE_SENDING=false                   # à laisser à false pour la première mise en service
 # TUNNEL_TOKEN=...                     # modèle autonome uniquement
 ```
@@ -95,7 +95,7 @@ Vérifier :
 docker compose ps                          # "healthy"/"running"
 docker compose logs -f icloud-mail-mcp     # "icloud-mail-mcp http server listening"
 curl https://icloud-mail-mcp.exemple.com/health
-# {"status":"ok","version":"0.1.1"}
+# {"status":"ok","version":"0.1.2"}
 ```
 
 Le `/health` répond sans token — c'est voulu, le healthcheck Docker en a besoin. Il ne révèle que le
@@ -178,10 +178,27 @@ n'est pas utilisé et le `MCP_BEARER_TOKEN` ne sert pas à authentifier (aucune 
 validation de configuration l'exige toujours — n'importe quelle valeur d'au moins 16 caractères
 convient.
 
-### Claude Desktop / claude.ai
+### Claude Desktop
 
-*Paramètres → Connecteurs → Ajouter un connecteur personnalisé*, avec l'URL
-`https://icloud-mail-mcp.exemple.com/mcp`.
+`claude_desktop_config.json` :
+
+```json
+"icloud-mail-mcp": {
+  "type": "http",
+  "url": "https://icloud-mail-mcp.exemple.com/mcp",
+  "headers": { "Authorization": "Bearer <votre token>" }
+}
+```
+
+### claude.ai (web / mobile)
+
+*Paramètres → Connecteurs → Ajouter un connecteur personnalisé* :
+
+- **URL** : `https://icloud-mail-mcp.exemple.com/mcp`
+- **Authentification** : le formulaire **interdit l'en-tête `Authorization`** et n'autorise qu'une
+  liste de noms. Choisir **`x-api-key`**, valeur = **le token brut** (`MCP_BEARER_TOKEN`, *sans* le
+  préfixe `Bearer `). Le serveur accepte les deux formes.
+- Passer le jeton par **en-tête**, pas par l'URL (une URL avec secret finit dans des logs).
 
 ### MCP Inspector (débogage)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -11,10 +11,11 @@ Cette page décrit ce que le projet protège, et ce qui reste à votre charge.
 
 ## Ce que le serveur fait pour vous
 
-**Authentification de tous les appels MCP.** `/mcp` exige `Authorization: Bearer <token>` en `POST`,
-`GET` et `DELETE`. Le token est comparé en temps constant (`timingSafeEqual`), après une
-vérification de longueur qui évite l'exception que lève cette fonction sur des tampons de tailles
-différentes.
+**Authentification de tous les appels MCP.** `/mcp` exige le token en `POST`, `GET` et `DELETE`,
+via `Authorization: Bearer <token>` ou `X-Api-Key: <token>` (jeton brut — cette seconde forme pour
+les connecteurs claude.ai, qui interdisent l'en-tête `Authorization`). Le token est comparé en
+temps constant (`timingSafeEqual`), après une vérification de longueur qui évite l'exception que
+lève cette fonction sur des tampons de tailles différentes.
 
 **TLS partout.** IMAP sur le port 993 en TLS implicite ; SMTP sur 587 avec `requireTLS: true` — si
 le serveur refuse STARTTLS, l'envoi échoue plutôt que de partir en clair.
@@ -88,6 +89,8 @@ C'est la seule chose qui sépare votre boîte mail d'Internet une fois le tunnel
 
 - Générez-le avec `openssl rand -hex 32`. N'inventez pas de token « mémorisable ».
 - Ne le collez ni dans une conversation, ni dans un ticket, ni dans un dépôt.
+- Se présente en `Authorization: Bearer <token>` **ou** `X-Api-Key: <token>` — même token, même
+  niveau d'accès. À passer par en-tête, jamais dans l'URL.
 - Pour le changer : nouvelle valeur dans `.env`, `docker compose up -d`, puis mise à jour de la
   configuration du client MCP. Toutes les sessions existantes sont invalidées.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -44,7 +44,7 @@ seul un booléen « configuré » est exposé à leur sujet.
 
 ```jsonc
 {
-  "server": { "name": "icloud-mail", "version": "0.1.1" },
+  "server": { "name": "icloud-mail", "version": "0.1.2" },
   "account": {
     "email": "vous@icloud.com",
     "imap": { "host": "imap.mail.me.com", "port": 993 },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "icloud-mail-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "icloud-mail-mcp",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "icloud-mail-mcp",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MCP server exposing iCloud Mail (IMAP/SMTP) as tools for Claude",
   "type": "module",
   "engines": {

--- a/src/http/auth.ts
+++ b/src/http/auth.ts
@@ -11,14 +11,36 @@ function safeEqual(a: string, b: string): boolean {
   return timingSafeEqual(bufA, bufB);
 }
 
+/**
+ * Jeton d'appel, cherché dans deux en-têtes :
+ *
+ * - `Authorization: Bearer <jeton>` — le cas courant (Claude Code, Claude
+ *   Desktop, MCP Inspector, curl).
+ * - `X-Api-Key: <jeton>` — les connecteurs personnalisés de claude.ai
+ *   interdisent l'en-tête `Authorization` et n'autorisent qu'une liste blanche
+ *   de noms, dont `x-api-key`. Jeton brut, sans préfixe.
+ *
+ * Un en-tête répété (donc `string[]`) est ignoré.
+ */
+function extractToken(req: Request): string | undefined {
+  const authorization = req.headers.authorization;
+  if (authorization?.startsWith('Bearer ')) {
+    return authorization.slice('Bearer '.length);
+  }
+  const apiKey = req.headers['x-api-key'];
+  if (typeof apiKey === 'string' && apiKey.length > 0) {
+    return apiKey;
+  }
+  return undefined;
+}
+
 export function bearerAuth(req: Request, res: Response, next: NextFunction): void {
-  const header = req.headers.authorization;
-  const token = header?.startsWith('Bearer ') ? header.slice('Bearer '.length) : undefined;
+  const token = extractToken(req);
 
   if (!token || !safeEqual(token, config.MCP_BEARER_TOKEN)) {
     res.status(401).json({
       jsonrpc: '2.0',
-      error: { code: -32001, message: 'Unauthorized: missing or invalid bearer token' },
+      error: { code: -32001, message: 'Unauthorized: missing or invalid token' },
       id: null,
     });
     return;

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -7,7 +7,7 @@ import { config } from '../src/config.js';
 
 const VALID = config.MCP_BEARER_TOKEN;
 
-function run(authorization?: string) {
+function invoke(headers: Record<string, string | string[] | undefined>) {
   const res = {
     statusCode: undefined as number | undefined,
     body: undefined as Record<string, unknown> | undefined,
@@ -22,11 +22,16 @@ function run(authorization?: string) {
   };
   let nextCalled = false;
 
-  bearerAuth({ headers: { authorization } } as Request, res as unknown as Response, () => {
+  bearerAuth({ headers } as Request, res as unknown as Response, () => {
     nextCalled = true;
   });
 
   return { res, nextCalled };
+}
+
+/** Raccourci historique : ne pose que l'en-tête `Authorization`. */
+function run(authorization?: string) {
+  return invoke({ authorization });
 }
 
 describe('bearerAuth', () => {
@@ -47,7 +52,7 @@ describe('bearerAuth', () => {
     assert.equal(res.body?.jsonrpc, '2.0');
     assert.deepEqual(res.body?.error, {
       code: -32001,
-      message: 'Unauthorized: missing or invalid bearer token',
+      message: 'Unauthorized: missing or invalid token',
     });
   });
 
@@ -87,5 +92,34 @@ describe('bearerAuth', () => {
   it('rejette "Bearer" sans token', () => {
     const { nextCalled } = run('Bearer ');
     assert.equal(nextCalled, false);
+  });
+
+  describe('en-tête X-Api-Key (connecteurs claude.ai)', () => {
+    it('laisse passer le bon token en jeton brut', () => {
+      const { nextCalled, res } = invoke({ 'x-api-key': VALID });
+      assert.equal(nextCalled, true);
+      assert.equal(res.statusCode, undefined);
+    });
+
+    it('rejette un mauvais token de même longueur', () => {
+      const { nextCalled, res } = invoke({ 'x-api-key': 'x'.repeat(VALID.length) });
+      assert.equal(nextCalled, false);
+      assert.equal(res.statusCode, 401);
+    });
+
+    it('rejette un token plus court sans planter', () => {
+      const { nextCalled } = invoke({ 'x-api-key': 'court' });
+      assert.equal(nextCalled, false);
+    });
+
+    it('ignore un en-tête répété (string[])', () => {
+      const { nextCalled } = invoke({ 'x-api-key': [VALID, VALID] });
+      assert.equal(nextCalled, false);
+    });
+
+    it('Authorization: Bearer valide a la priorité sur un X-Api-Key erroné', () => {
+      const { nextCalled } = invoke({ authorization: `Bearer ${VALID}`, 'x-api-key': 'faux' });
+      assert.equal(nextCalled, true);
+    });
   });
 });


### PR DESCRIPTION
## Problème

Le formulaire « connecteur personnalisé » de claude.ai **interdit l'en-tête `Authorization`** et n'autorise qu'une liste blanche de noms (`x-api-key`, `api-key`, …). Impossible d'y brancher le serveur tel quel.

## Changement

`/mcp` lit désormais le token depuis **`X-Api-Key: <token>`** (jeton brut, sans préfixe) en plus de `Authorization: Bearer <token>`. Même token, même niveau d'accès. Un en-tête `X-Api-Key` répété (`string[]`) est ignoré. `Authorization: Bearer` reste inchangé pour Claude Code / Desktop / Inspector / curl.

Message d'erreur généralisé : `missing or invalid bearer token` → `missing or invalid token`.

## Docs

README, `docs/deployment.md` (sections Claude Desktop + claude.ai), `docs/security.md`, `docs/configuration.md`, `.env.example` : branchement claude.ai documenté (choisir `x-api-key`, token brut, par en-tête pas par URL).

## Tests

345 tests (+5 : `X-Api-Key` valide/invalide/court/répété, priorité `Authorization`). typecheck + lint + build verts.

## Release 0.1.2

`package.json` → `0.1.2`, `CHANGELOG` daté. Après merge : `git tag -a v0.1.2 -m v0.1.2 && git push origin v0.1.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)