### PR TITLE
CD : déploiement SSH sur release + bouton (ne pas merger avant le 2026-09-02)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,8 @@ dist
 # Non nécessaires à la construction de l'image (dépendances de dev seules).
 test
 docs
+deploy
+docker-compose*.yml
 *.md
 !README.md
 .prettierrc.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,60 @@
+name: Deploy
+run-name: "Deploy ${{ github.event.release.tag_name || inputs.version }}"
+
+# Deux déclencheurs :
+#   - une release publiée  -> déploie ce tag automatiquement ;
+#   - le bouton "Run workflow" (onglet Actions) -> déploie la version choisie.
+# Aucun des deux n'est déclenchable depuis un fork : seul un compte avec write
+# access peut lancer le déploiement, et les secrets ne sont jamais exposés aux
+# PR de forks.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version à déployer (X.Y.Z ou 'latest')"
+        default: latest
+        type: string
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Déployer via SSH
+        env:
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          SSH_HOST: ${{ secrets.DEPLOY_HOST }}
+          SSH_PORT: ${{ secrets.DEPLOY_PORT }}
+          SSH_USER: ${{ secrets.DEPLOY_USER }}
+          SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+          VERSION: ${{ github.event.release.tag_name || inputs.version }}
+        run: |
+          set -euo pipefail
+          [ -n "$SSH_KEY" ] && [ -n "$SSH_HOST" ] && [ -n "$SSH_USER" ] || {
+            echo "::error::secrets DEPLOY_SSH_KEY / DEPLOY_HOST / DEPLOY_USER manquants"
+            exit 1
+          }
+
+          mkdir -p ~/.ssh
+          install -m600 /dev/stdin ~/.ssh/deploy_key <<< "$SSH_KEY"
+          if [ -n "${SSH_KNOWN_HOSTS:-}" ]; then
+            printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+            strict=yes
+          else
+            echo "::warning::DEPLOY_KNOWN_HOSTS non défini — TOFU sur la clé hôte"
+            strict=accept-new
+          fi
+
+          v="${VERSION#v}"
+          echo "Déploiement de $v"
+          # La clé de déploiement est forcée (authorized_keys command=...) sur
+          # deploy/deploy.sh ; on ne passe que la version.
+          ssh -i ~/.ssh/deploy_key -p "${SSH_PORT:-22}" \
+            -o "StrictHostKeyChecking=$strict" -o UserKnownHostsFile=~/.ssh/known_hosts \
+            -o ConnectTimeout=15 -o BatchMode=yes \
+            "$SSH_USER@$SSH_HOST" "$v"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,12 @@ versionnage [SemVer](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
-_Rien pour l'instant._
+### Ajouté
+
+- **Déploiement continu.** `.github/workflows/deploy.yml` + `deploy/deploy.sh` :
+  déploiement sur l'hôte via SSH, automatique à chaque release publiée et à la
+  demande (bouton *Run workflow*). Aucun agent résident sur l'hôte. Clé SSH
+  dédiée forcée sur `deploy.sh`. Mise en place : `deploy/README.md`.
 
 ## [0.1.2] - 2026-08-31
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,62 @@
+# Déploiement continu
+
+Le workflow [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml) se connecte en SSH à
+l'hôte et y lance [`deploy.sh`](deploy.sh). Deux déclencheurs : une **release publiée** (déploie ce
+tag) et le **bouton *Run workflow*** de l'onglet *Actions* (choix de la version).
+
+Aucun runner, aucun agent résident sur l'hôte : `sshd` suffit.
+
+## Mise en place (sur l'hôte)
+
+Le dossier de déploiement contient `docker-compose.yml` + `.env` (voir [deployment.md](../docs/deployment.md)).
+On y ajoute une copie de ce dossier `deploy/` :
+
+```bash
+cd /opt/icloud-mail-mcp                 # le dossier avec docker-compose.yml + .env
+mkdir -p deploy
+curl -o deploy/deploy.sh https://raw.githubusercontent.com/leolesimple/icloud-mail-mcp/main/deploy/deploy.sh
+chmod +x deploy/deploy.sh
+```
+
+Générer une **paire de clés dédiée** au déploiement (pas de passphrase) :
+
+```bash
+ssh-keygen -t ed25519 -f ~/.ssh/icloud-mail-mcp-deploy -N "" -C "deploy:icloud-mail-mcp"
+```
+
+Ajouter la **clé publique** à `~/.ssh/authorized_keys`, **forcée sur `deploy.sh`** — une clé fuitée
+ne peut alors rien faire d'autre que déclencher un déploiement :
+
+```
+command="/opt/icloud-mail-mcp/deploy/deploy.sh",no-port-forwarding,no-agent-forwarding,no-X11-forwarding,no-pty ssh-ed25519 AAAA... deploy:icloud-mail-mcp
+```
+
+Le compte SSH doit pouvoir parler à Docker (`docker compose` dans `deploy.sh`) — membre du groupe
+`docker`, ou un `sudo` sans mot de passe ciblé.
+
+## Secrets GitHub (repo → Settings → Secrets and variables → Actions)
+
+| Secret | Valeur |
+|---|---|
+| `DEPLOY_SSH_KEY` | la **clé privée** `~/.ssh/icloud-mail-mcp-deploy` (contenu complet) |
+| `DEPLOY_HOST` | hôte SSH (IP ou nom) |
+| `DEPLOY_PORT` | port SSH (par défaut `22`) |
+| `DEPLOY_USER` | compte SSH |
+| `DEPLOY_KNOWN_HOSTS` | *(recommandé)* sortie de `ssh-keyscan -p <port> <hôte>` — sinon le workflow fait du TOFU sur la clé hôte |
+
+## Test
+
+Onglet *Actions* → *Deploy* → *Run workflow* → version `latest` → *Run*. Le job doit finir vert
+(`deploy.sh` échoue si le conteneur ne devient pas `healthy`). Vérifier ensuite :
+`curl https://<hostname>/health`.
+
+## Modèle de menace
+
+- `workflow_dispatch` et `release` ne sont **pas** déclenchables depuis un fork ; les secrets ne
+  sont jamais exposés à une PR de fork. Seul un compte avec write access lance le déploiement.
+- La clé de déploiement est **forcée** sur `deploy.sh` : pas de shell, pas de forwarding.
+- `deploy.sh` **valide** la version (`^(latest|X.Y.Z)$`) avant de toucher à `.env`.
+- Le pire cas d'une clé privée fuitée : un tiers peut faire (re)déployer une version **déjà publiée**
+  sur GHCR. Il ne peut pas exécuter de commande arbitraire ni lire `.env`.
+- Retour arrière : *Run workflow* avec l'ancienne version, ou à la main
+  (`deploy.sh <version>` sur l'hôte).

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Déploie icloud-mail-mcp sur l'hôte : écrit la version voulue dans .env, tire
+# l'image GHCR, redémarre, attend que le conteneur soit `healthy`.
+#
+# Deux usages :
+#
+#   ./deploy.sh 0.1.2          # à la main (ou 'latest')
+#
+#   command="/opt/icloud-mail-mcp/deploy/deploy.sh",no-port-forwarding,no-pty,no-agent-forwarding,no-X11-forwarding ssh-ed25519 AAAA... deploy
+#     dans ~/.ssh/authorized_keys : la clé de déploiement CI ne peut lancer QUE
+#     ce script. La version demandée arrive alors dans $SSH_ORIGINAL_COMMAND.
+#
+# Le dossier de déploiement (docker-compose.yml + .env) est le PARENT de ce
+# script — adapter WORKDIR si l'arborescence diffère.
+set -euo pipefail
+
+WORKDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTAINER="icloud-mail-mcp"
+HEALTH_TIMEOUT=60 # secondes
+
+# Version : argument direct, sinon dernier mot de $SSH_ORIGINAL_COMMAND (la
+# clé CI est forcée sur ce script, le client ne passe que la version), sinon
+# 'latest'.
+if [[ -n "${1:-}" ]]; then
+  version="$1"
+elif [[ -n "${SSH_ORIGINAL_COMMAND:-}" ]]; then
+  version="${SSH_ORIGINAL_COMMAND##* }"
+else
+  version="latest"
+fi
+version="${version#v}"
+if [[ ! "$version" =~ ^(latest|[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+  echo "deploy: version invalide : '$version'" >&2
+  exit 2
+fi
+
+cd "$WORKDIR"
+[[ -f .env && -f docker-compose.yml ]] || {
+  echo "deploy: .env ou docker-compose.yml absent dans $WORKDIR" >&2
+  exit 1
+}
+
+echo "deploy: $CONTAINER -> $version"
+if grep -q '^ICLOUD_MAIL_MCP_VERSION=' .env; then
+  sed -i "s/^ICLOUD_MAIL_MCP_VERSION=.*/ICLOUD_MAIL_MCP_VERSION=$version/" .env
+else
+  printf '\nICLOUD_MAIL_MCP_VERSION=%s\n' "$version" >>.env
+fi
+
+docker compose pull
+docker compose up -d
+
+deadline=$((SECONDS + HEALTH_TIMEOUT))
+while (( SECONDS < deadline )); do
+  status="$(docker inspect -f '{{.State.Health.Status}}' "$CONTAINER" 2>/dev/null || echo missing)"
+  case "$status" in
+    healthy)
+      running="$(docker inspect -f '{{index .Config.Labels "org.opencontainers.image.version"}}' "$CONTAINER" 2>/dev/null)"
+      echo "deploy: OK — image ${running:-?} healthy"
+      exit 0
+      ;;
+    unhealthy)
+      echo "deploy: conteneur unhealthy" >&2
+      docker compose logs --tail=50 "$CONTAINER" >&2
+      exit 1
+      ;;
+  esac
+  sleep 2
+done
+
+echo "deploy: pas healthy après ${HEALTH_TIMEOUT}s" >&2
+docker compose logs --tail=50 "$CONTAINER" >&2
+exit 1

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -232,6 +232,19 @@ au prochain appel.
 
 ---
 
+## Déploiement continu (optionnel)
+
+[`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml) déploie sur l'hôte :
+
+- **automatiquement** à chaque GitHub Release publiée (le tag est déployé) ;
+- **à la demande** via le bouton *Run workflow* de l'onglet *Actions* (choix de la version).
+
+Il se connecte en SSH et exécute [`deploy/deploy.sh`](../deploy/deploy.sh) : écriture de la version
+dans `.env`, `docker compose pull`, `up -d`, puis attente de `healthy` (échec sinon). Aucun runner
+ni agent résident sur l'hôte. Mise en place et modèle de menace : [`deploy/README.md`](../deploy/README.md).
+
+---
+
 ## Dépannage
 
 | Symptôme | Piste |


### PR DESCRIPTION
Ferme #46.

## Contenu

- **`.github/workflows/deploy.yml`** — déploiement SSH, déclenché par `release: published` **et** `workflow_dispatch` (bouton *Run workflow*, choix de version). Aucun runner self-hosted.
- **`deploy/deploy.sh`** — exécuté sur l'hôte : écrit la version dans `.env`, `docker compose pull` + `up -d`, attend `healthy` (échoue sinon). Valide la version (`^(latest|X.Y.Z)$`) avant de toucher `.env`.
- **`deploy/README.md`** — mise en place (clé SSH dédiée forcée sur `deploy.sh` via `authorized_keys`, secrets `DEPLOY_*`) + modèle de menace.
- `docs/deployment.md` : section « Déploiement continu ». `.dockerignore` : exclut `deploy/` et `docker-compose*.yml` du contexte de build.

## Empreinte hôte

Zéro résident (`sshd` déjà là). Plus léger que le runner self-hosted, et donne le bouton **+** le deploy-auto-sur-release.

## Avant de merger

- [ ] Générer la paire de clés de déploiement, poser la publique en `command=".../deploy.sh"` dans `authorized_keys` du NUC
- [ ] Créer les secrets `DEPLOY_SSH_KEY` / `DEPLOY_HOST` / `DEPLOY_PORT` / `DEPLOY_USER` / `DEPLOY_KNOWN_HOSTS`
- [ ] Poser `deploy/deploy.sh` sur le NUC (`/opt/icloud-mail-mcp/deploy/`)

**⏳ Ne pas merger avant le 2026-09-02.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)